### PR TITLE
fix: migrate navigation to Expo Router and fix emergency flow

### DIFF
--- a/app/(tabs)/emergency.tsx
+++ b/app/(tabs)/emergency.tsx
@@ -1,5 +1,30 @@
 import { EmergencyDetailsScreen } from '@presentation/screens/emergency-details-screen';
+import { EmergencySetupScreen } from '@presentation/screens/emergency-setup-screen';
+import { useEmergencyInfo } from '@presentation/hooks/use-emergency-info';
+import { useFocusEffect } from 'expo-router';
+import { useCallback } from 'react';
+import { ActivityIndicator, View } from 'react-native';
 
-export default function Emergency() {
+export default function EmergencyTab() {
+  const { emergencyInfo, isLoading, refresh } = useEmergencyInfo();
+
+  useFocusEffect(
+    useCallback(() => {
+      refresh();
+    }, [])
+  );
+
+  if (isLoading) {
+    return (
+      <View className="flex-1 bg-background-primary items-center justify-center">
+        <ActivityIndicator size="large" color="#3B82F6" />
+      </View>
+    );
+  }
+
+  if (!emergencyInfo) {
+    return <EmergencySetupScreen />;
+  }
+
   return <EmergencyDetailsScreen />;
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout() {
           }} 
         />
         <Stack.Screen name="emergency" options={{ headerShown: false }} />
-        <Stack.Screen name="emergency-details" options={{ headerShown: false }} />
+        <Stack.Screen name="emergency-setup" options={{ headerShown: false }} />
         <Stack.Screen name="add-credit-card" options={{ headerShown: false }} />
         <Stack.Screen name="document-details" options={{ headerShown: false }} />
         <Stack.Screen name="add-document" options={{ headerShown: false }} />

--- a/app/emergency-setup.tsx
+++ b/app/emergency-setup.tsx
@@ -1,0 +1,5 @@
+import { EmergencySetupScreen } from '@presentation/screens/emergency-setup-screen';
+
+export default function EmergencySetupRoute() {
+  return <EmergencySetupScreen />;
+}

--- a/app/emergency.tsx
+++ b/app/emergency.tsx
@@ -1,5 +1,23 @@
+import { EmergencyDetailsScreen } from '@presentation/screens/emergency-details-screen';
 import { EmergencySetupScreen } from '@presentation/screens/emergency-setup-screen';
+import { useEmergencyInfo } from '@presentation/hooks/use-emergency-info';
+import { ActivityIndicator, View } from 'react-native';
 
 export default function EmergencyRoute() {
-  return <EmergencySetupScreen />;
+  const { emergencyInfo, isLoading } = useEmergencyInfo();
+
+  if (isLoading) {
+    return (
+      <View className="flex-1 bg-background-primary items-center justify-center">
+        <ActivityIndicator size="large" color="#3B82F6" />
+      </View>
+    );
+  }
+
+  // Middleware: sem dados → setup, com dados → detalhes
+  if (!emergencyInfo) {
+    return <EmergencySetupScreen />;
+  }
+
+  return <EmergencyDetailsScreen />;
 }

--- a/src/presentation/screens/emergency-details-screen.tsx
+++ b/src/presentation/screens/emergency-details-screen.tsx
@@ -1,11 +1,18 @@
 import { View, Text, ScrollView, Pressable, ActivityIndicator } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useNavigation } from '@react-navigation/native';
+import { useFocusEffect, useRouter } from 'expo-router';
 import { useEmergencyInfo } from '@presentation/hooks/use-emergency-info';
+import { useCallback } from 'react';
 
 export function EmergencyDetailsScreen() {
-  const navigation = useNavigation();
-  const { emergencyInfo, isLoading } = useEmergencyInfo();
+  const router = useRouter();
+  const { emergencyInfo, isLoading, refresh } = useEmergencyInfo();
+
+  useFocusEffect(
+    useCallback(() => {
+      refresh();
+    }, [])
+  );
 
   if (isLoading) {
     return (
@@ -22,14 +29,19 @@ export function EmergencyDetailsScreen() {
           <View className="flex-row items-center justify-between px-6 py-4 border-b border-ui-border">
             <Pressable 
               className="w-10 h-10 items-center justify-center"
-              onPress={() => navigation.goBack()}
+              onPress={() => router.back()}
             >
               <Text className="text-2xl text-text-primary">←</Text>
             </Pressable>
             <Text className="text-lg font-bold text-text-primary">
               Emergency Profile
             </Text>
-            <View className="w-10" />
+            <Pressable
+              className="w-10 h-10 items-center justify-center"
+              onPress={() => router.push('/emergency-setup')}
+            >
+              <Text className="text-xl text-primary-main">✏️</Text>
+            </Pressable>
           </View>
           
           <View className="flex-1 items-center justify-center px-6">
@@ -42,7 +54,7 @@ export function EmergencyDetailsScreen() {
             </Text>
             <Pressable 
               className="bg-primary-main rounded-xl py-3 px-6 active:bg-primary-dark"
-              onPress={() => navigation.navigate('emergency' as never)}
+              onPress={() => router.push('/emergency-setup')}
             >
               <Text className="text-base font-bold text-text-primary">
                 Set Up Emergency Profile
@@ -60,7 +72,7 @@ export function EmergencyDetailsScreen() {
         <View className="flex-row items-center justify-between px-6 py-4 border-b border-ui-border">
           <Pressable 
             className="w-10 h-10 items-center justify-center"
-            onPress={() => navigation.goBack()}
+            onPress={() => router.back()}
           >
             <Text className="text-2xl text-text-primary">←</Text>
           </Pressable>
@@ -69,7 +81,7 @@ export function EmergencyDetailsScreen() {
           </Text>
           <Pressable 
             className="w-10 h-10 items-center justify-center"
-            onPress={() => navigation.navigate('emergency' as never)}
+            onPress={() => router.push('/emergency-setup')}
           >
             <Text className="text-xl text-primary-main">✏️</Text>
           </Pressable>
@@ -239,27 +251,6 @@ export function EmergencyDetailsScreen() {
           </View>
         </ScrollView>
 
-        <View className="flex-row bg-background-secondary border-t border-ui-border">
-          <Pressable 
-            className="flex-1 items-center py-3"
-            onPress={() => navigation.navigate('home' as never)}
-          >
-            <Text className="text-2xl mb-1">💼</Text>
-            <Text className="text-xs font-medium text-text-secondary">Wallet</Text>
-          </Pressable>
-          <Pressable className="flex-1 items-center py-3">
-            <Text className="text-2xl mb-1">❤️</Text>
-            <Text className="text-xs font-medium text-text-secondary">Health</Text>
-          </Pressable>
-          <Pressable className="flex-1 items-center py-3">
-            <Text className="text-2xl mb-1">🚨</Text>
-            <Text className="text-xs font-medium text-primary-main">Emergency</Text>
-          </Pressable>
-          <Pressable className="flex-1 items-center py-3">
-            <Text className="text-2xl mb-1">⚙️</Text>
-            <Text className="text-xs font-medium text-text-secondary">Settings</Text>
-          </Pressable>
-        </View>
       </View>
     </SafeAreaView>
   );

--- a/src/presentation/screens/wallet-home-screen.tsx
+++ b/src/presentation/screens/wallet-home-screen.tsx
@@ -1,16 +1,15 @@
 import { View, Text, ScrollView, Pressable, ActivityIndicator } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { ActionCard } from '@presentation/components/action-card';
-import { useNavigation, NavigationProp } from '@react-navigation/native';
+import { useRouter } from 'expo-router';
 import { useDocuments } from '@presentation/hooks/use-documents';
 import { useCreditCards } from '@presentation/hooks/use-credit-cards';
 import { useUserProfile } from '@presentation/hooks/use-user-profile';
-import { RootStackParamList } from '@presentation/types/navigation';
 import { SvgIcon } from '@presentation/components/svg-icon';
 import { useEffect } from 'react';
 
 export function WalletHomeScreen() {
-  const navigation = useNavigation<NavigationProp<RootStackParamList>>();
+  const router = useRouter();
   const { documents, isLoading: documentsLoading } = useDocuments();
   const { cards, isLoading: cardsLoading } = useCreditCards();
   const { profile, isLoading: profileLoading } = useUserProfile();
@@ -20,9 +19,9 @@ export function WalletHomeScreen() {
   // Redirect to profile setup if no profile exists
   useEffect(() => {
     if (!profileLoading && !profile) {
-      navigation.navigate('profile-setup');
+      router.push('/profile-setup');
     }
-  }, [profile, profileLoading, navigation]);
+  }, [profile, profileLoading, router]);
 
   const getDocumentIcon = (type: string) => {
     switch (type) {
@@ -87,19 +86,19 @@ export function WalletHomeScreen() {
                 icon={<SvgIcon name="new-card" width={28} height={28} />}
                 label={getCardLabel()} 
                 variant="primary"
-                onPress={() => navigation.navigate('add-credit-card')}
+                onPress={() => router.push('/add-credit-card')}
               />
               <ActionCard 
                 icon={<SvgIcon name="triangle-allergies" width={28} height={28} />}
                 label="Emergency" 
                 variant="danger"
-                onPress={() => navigation.navigate('emergency')}
+                onPress={() => router.push('/emergency')}
               />
               <ActionCard 
                 icon={<SvgIcon name="add-doc" width={28} height={28} />}
                 label="Add Doc" 
                 variant="secondary"
-                onPress={() => navigation.navigate('add-document')}
+                onPress={() => router.push('/add-document')}
               />
             </View>
           </View>
@@ -116,7 +115,7 @@ export function WalletHomeScreen() {
             </Text>
             <Pressable 
               className="bg-white rounded-xl py-3.5 items-center active:opacity-90"
-              onPress={() => navigation.navigate('select-documents')}
+              onPress={() => router.push('/select-documents')}
             >
               <Text className="text-base md:text-lg font-bold text-primary-main">Start Sharing</Text>
             </Pressable>
@@ -148,7 +147,7 @@ export function WalletHomeScreen() {
                 <Pressable 
                   key={doc.id}
                   className="bg-background-secondary rounded-2xl p-4 active:opacity-80"
-                  onPress={() => navigation.navigate('document-details', { documentId: doc.id })}
+                  onPress={() => router.push({ pathname: '/document-details', params: { documentId: doc.id } })}
                 >
                   <View className="flex-row items-start justify-between">
                     <View className="flex-row flex-1">


### PR DESCRIPTION
## Summary

- Migrated `WalletHomeScreen` and `EmergencyDetailsScreen` from `useNavigation` (React Navigation) to `useRouter` (Expo Router), making navigation consistent across the app
- Fixed the emergency flow with a middleware route (`/emergency`) that redirects to setup or details based on whether data exists
- Created a dedicated `/emergency-setup` route for creating and editing emergency info, with the edit icon (✏️) in the Emergency Profile header correctly navigating to it
- Added `useFocusEffect` to refresh emergency data when returning from the setup screen, ensuring updated data is always displayed

## Changes

### Navigation migration
- `WalletHomeScreen`: replaced all `navigation.navigate()` calls with `router.push()` and fixed `document-details` params to use `{ pathname, params }` format
- `EmergencyDetailsScreen`: replaced `useNavigation` with `useRouter`, removed obsolete bottom navigation bar

### Emergency routing
- `app/emergency.tsx`: converted to a middleware — shows `EmergencySetupScreen` if no data exists, otherwise shows `EmergencyDetailsScreen`
- `app/emergency-setup.tsx`: new dedicated route for the setup/edit screen
- `app/(tabs)/emergency.tsx`: same conditional logic as the middleware, with `useFocusEffect` to refresh on tab focus
- `app/_layout.tsx`: replaced `emergency-details` stack screen with `emergency-setup`

## Test plan

- [ ] Open app and tap "Emergency" quick action on home screen — should show details if data exists, or setup if not
- [ ] Tap the Emergency tab — same conditional behavior
- [ ] On Emergency Profile screen, tap the ✏️ edit icon — should navigate to the setup/edit screen
- [ ] Edit data and save — should return to details screen with updated data displayed
- [ ] Navigate to add-credit-card, add-document, select-documents, document-details — all should work correctly

Made with [Cursor](https://cursor.com)