### PR TITLE
ci: add label-router workflow to notify Orchestrator via Slack

### DIFF
--- a/.github/workflows/label-router.yml
+++ b/.github/workflows/label-router.yml
@@ -1,0 +1,39 @@
+name: Label Router
+
+on:
+  issues:
+    types: [labeled]
+  pull_request:
+    types: [labeled]
+
+jobs:
+  notify-orchestrator:
+    name: Notify Orchestrator
+    runs-on: ubuntu-latest
+
+    # Only react to routing labels — ignore all others
+    if: |
+      contains(fromJson('["task","needs-tests","needs-fix","tests-ready","qa-approved","qa-changes-requested"]'), github.event.label.name)
+
+    steps:
+      - name: Build message
+        id: msg
+        run: |
+          if [ "${{ github.event_name }}" = "issues" ]; then
+            KIND="issue"
+          else
+            KIND="pr"
+          fi
+          NUMBER="${{ github.event.issue.number || github.event.pull_request.number }}"
+          LABEL="${{ github.event.label.name }}"
+          echo "text=🔔 github: label=${LABEL} ${KIND}=#${NUMBER}" >> $GITHUB_OUTPUT
+
+      - name: Post to Slack #orchestrator
+        run: |
+          curl -s -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "channel": "C0AL2R8S858",
+              "text": "${{ steps.msg.outputs.text }}"
+            }'


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/label-router.yml`
- Triggers on `issues: [labeled]` and `pull_request: [labeled]`
- Filters to routing labels only: `task`, `needs-tests`, `needs-fix`, `tests-ready`, `qa-approved`, `qa-changes-requested`
- Posts to `#orchestrator` in Slack via `SLACK_BOT_TOKEN` secret (already configured)
- Format: `🔔 github: label=<label> issue=#N` or `pr=#N`

## How it fits the pipeline

This replaces the fragile `sessions_send` approach where agents notified the Orchestrator directly. Now agents just change the GitHub label and stop — GitHub Actions handles the notification.

## Test plan

- [ ] Add label `task` to an issue → confirm message appears in `#orchestrator`
- [ ] Add label `needs-tests` to a PR → confirm message appears in `#orchestrator`
- [ ] Add an unrelated label (e.g. `bug`) → confirm workflow does NOT run
