### PR TITLE
hotfix: add label-router workflow

### DIFF
--- a/.github/workflows/label-router.yml
+++ b/.github/workflows/label-router.yml
@@ -1,0 +1,39 @@
+name: Label Router
+
+on:
+  issues:
+    types: [labeled]
+  pull_request:
+    types: [labeled]
+
+jobs:
+  notify-orchestrator:
+    name: Notify Orchestrator
+    runs-on: ubuntu-latest
+
+    # Only react to routing labels — ignore all others
+    if: |
+      contains(fromJson('["task","needs-tests","needs-fix","tests-ready","qa-approved","qa-changes-requested"]'), github.event.label.name)
+
+    steps:
+      - name: Build message
+        id: msg
+        run: |
+          if [ "${{ github.event_name }}" = "issues" ]; then
+            KIND="issue"
+          else
+            KIND="pr"
+          fi
+          NUMBER="${{ github.event.issue.number || github.event.pull_request.number }}"
+          LABEL="${{ github.event.label.name }}"
+          echo "text=🔔 github: label=${LABEL} ${KIND}=#${NUMBER}" >> $GITHUB_OUTPUT
+
+      - name: Post to Slack #orchestrator
+        run: |
+          curl -s -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "channel": "C0AL2R8S858",
+              "text": "${{ steps.msg.outputs.text }}"
+            }'


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/label-router.yml` to the default branch (`main`)
- Required for GitHub Actions to trigger on `issues` and `pull_request` label events
- No production code changed — CI infrastructure only

## Why main directly

GitHub Actions for `issues: [labeled]` events only run from the default branch.
This workflow is pipeline infrastructure, not a product feature — does not need to wait for v1.0.0.
