### PR TITLE
feat(pipeline): add wip label for task visibility

### DIFF
--- a/.github/workflows/label-router.yml
+++ b/.github/workflows/label-router.yml
@@ -13,7 +13,7 @@ jobs:
 
     # Only react to routing labels — ignore all others
     if: |
-      contains(fromJson('["task","needs-tests","needs-fix","tests-ready","qa-approved","qa-changes-requested"]'), github.event.label.name)
+      contains(fromJson('["task","wip","needs-tests","needs-fix","tests-ready","qa-approved","qa-changes-requested"]'), github.event.label.name)
 
     steps:
       - name: Build variables


### PR DESCRIPTION
## Summary

- Adds `wip` to the GitHub Actions label router filter
- Senior Dev adds this label as first action when starting a task
- Orchestrator picks it up and posts `⚙️ Senior Dev iniciou TASK-N` in the thread

## Why

Previously there was no visibility on whether Senior Dev had started working — the Orchestrator would activate the agent and then nothing would appear in `#thoryx-squad` until a PR was opened. The `wip` label closes that gap.

## How to test

1. Add label `wip` to any issue → GitHub Actions should notify `#orchestrator`
2. Orchestrator should post `⚙️ Senior Dev iniciou TASK-N` in the task thread

Closes #35
