### PR TITLE
feat(pipeline): route GitHub Actions directly to agent channels

### DIFF
--- a/.github/workflows/label-router.yml
+++ b/.github/workflows/label-router.yml
@@ -7,8 +7,8 @@ on:
     types: [labeled]
 
 jobs:
-  notify-orchestrator:
-    name: Notify Orchestrator
+  route:
+    name: Route to Agent
     runs-on: ubuntu-latest
 
     # Only react to routing labels — ignore all others
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Build variables
-        id: msg
+        id: vars
         run: |
           if [ "${{ github.event_name }}" = "issues" ]; then
             KIND="issue"
@@ -28,29 +28,74 @@ jobs:
             NUMBER="${{ github.event.pull_request.number }}"
             TITLE="${{ github.event.pull_request.title }}"
           fi
-          LABEL="${{ github.event.label.name }}"
           echo "kind=${KIND}" >> $GITHUB_OUTPUT
           echo "number=${NUMBER}" >> $GITHUB_OUTPUT
-          echo "label=${LABEL}" >> $GITHUB_OUTPUT
+          echo "label=${{ github.event.label.name }}" >> $GITHUB_OUTPUT
           echo "title=${TITLE}" >> $GITHUB_OUTPUT
 
-      - name: Post to #orchestrator
+      - name: Open thread in #thoryx-squad (task only)
+        if: steps.vars.outputs.label == 'task' && steps.vars.outputs.kind == 'issue'
         run: |
+          PAYLOAD=$(jq -n \
+            --arg channel "C0AKW87DA78" \
+            --arg text "📋 ${{ steps.vars.outputs.title }}\nIssue: #${{ steps.vars.outputs.number }} — https://github.com/MarcosMatsuda/thoryx/issues/${{ steps.vars.outputs.number }}" \
+            '{channel: $channel, text: $text}')
           curl -s -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
             -H "Content-Type: application/json" \
-            -d "{
-              \"channel\": \"C0AL2R8S858\",
-              \"text\": \"🔔 github: label=${{ steps.msg.outputs.label }} ${{ steps.msg.outputs.kind }}=#${{ steps.msg.outputs.number }}\"
-            }"
+            -d "$PAYLOAD"
 
-      - name: Open task thread in #thoryx-squad
-        if: steps.msg.outputs.label == 'task' && steps.msg.outputs.kind == 'issue'
+      - name: Post status to #thoryx-squad
         run: |
+          LABEL="${{ steps.vars.outputs.label }}"
+          NUMBER="${{ steps.vars.outputs.number }}"
+
+          case "$LABEL" in
+            task)                 MSG="📋 TASK-${NUMBER} iniciada — Senior Dev ativado." ;;
+            wip)                  MSG="⚙️ Senior Dev iniciou TASK-${NUMBER}." ;;
+            needs-tests)          MSG="⚙️ PR #${NUMBER} aberto — Wolf escrevendo testes." ;;
+            needs-fix)            MSG="🔧 PR #${NUMBER} — bug encontrado. Senior Dev corrigindo." ;;
+            tests-ready)          MSG="🐺 Testes prontos — PR #${NUMBER}. QA ativado." ;;
+            qa-approved)          MSG="✅ PR #${NUMBER} aprovado por QA. Pronto para sua revisão e merge, Marcos." ;;
+            qa-changes-requested) MSG="❌ PR #${NUMBER} — mudanças solicitadas por QA. Senior Dev corrigindo." ;;
+          esac
+
+          PAYLOAD=$(jq -n --arg channel "C0AKW87DA78" --arg text "$MSG" '{channel: $channel, text: $text}')
           curl -s -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
             -H "Content-Type: application/json" \
-            -d "{
-              \"channel\": \"C0AKW87DA78\",
-              \"text\": \"📋 ${{ steps.msg.outputs.title }}\nIssue: #${{ steps.msg.outputs.number }} — https://github.com/MarcosMatsuda/thoryx/issues/${{ steps.msg.outputs.number }}\"
-            }"
+            -d "$PAYLOAD"
+
+      - name: Route to agent channel
+        run: |
+          LABEL="${{ steps.vars.outputs.label }}"
+          NUMBER="${{ steps.vars.outputs.number }}"
+          CHANNEL=""
+          TEXT=""
+
+          case "$LABEL" in
+            task)
+              CHANNEL="C0AL4T1JNBB"
+              TEXT="Issue #${NUMBER} has label task. Read the issue and implement it: gh issue view ${NUMBER} --repo MarcosMatsuda/thoryx\nIMPORTANT: cd /Users/marcosmatsuda/PROJECTS/MARCOSMATSUDA/thoryx && git checkout develop && git pull origin develop — do this FIRST."
+              ;;
+            needs-tests)
+              CHANNEL="C0ALT3YPRQ8"
+              TEXT="PR #${NUMBER} has label needs-tests. Write tests for this PR.\nIMPORTANT: cd /Users/marcosmatsuda/PROJECTS/MARCOSMATSUDA/thoryx && git checkout develop && git pull origin develop — do this FIRST."
+              ;;
+            needs-fix|qa-changes-requested)
+              CHANNEL="C0AL4T1JNBB"
+              TEXT="PR #${NUMBER} has label ${LABEL}. Read the PR comments and fix the reported issues: gh pr view ${NUMBER} --repo MarcosMatsuda/thoryx\nIMPORTANT: cd /Users/marcosmatsuda/PROJECTS/MARCOSMATSUDA/thoryx && git checkout develop && git pull origin develop — do this FIRST."
+              ;;
+            tests-ready)
+              CHANNEL="C0AKAGF1QCX"
+              TEXT="PR #${NUMBER} has label tests-ready. Review against the acceptance criteria in the linked issue.\nIMPORTANT: cd /Users/marcosmatsuda/PROJECTS/MARCOSMATSUDA/thoryx && git checkout develop && git pull origin develop — do this FIRST."
+              ;;
+          esac
+
+          if [ -n "$CHANNEL" ]; then
+            PAYLOAD=$(jq -n --arg channel "$CHANNEL" --arg text "$TEXT" '{channel: $channel, text: $text}')
+            curl -s -X POST https://slack.com/api/chat.postMessage \
+              -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
+              -H "Content-Type: application/json" \
+              -d "$PAYLOAD"
+          fi


### PR DESCRIPTION
## Summary

- GitHub Actions now posts directly to each agent's Slack channel based on the label
- Removes the Orchestrator from the routing critical path (no more `sessions_spawn` for routing)
- GitHub Actions also posts status messages to `#thoryx-squad` automatically
- Orchestrator is now monitoring-only (escalation + stuck task detection)

## Routing table

| Label | Channel |
|---|---|
| `task` on issue | `#senior-developer` |
| `needs-tests` on PR | `#test-writer` |
| `needs-fix` / `qa-changes-requested` on PR | `#senior-developer` |
| `tests-ready` on PR | `#qa` |
| `wip` / `qa-approved` | status only → `#thoryx-squad` |

## Why

The previous flow (GitHub Actions → #orchestrator → Orchestrator → sessions_spawn → Agent) had too many failure points. Direct routing eliminates the middleman.
