### PR TITLE
fix: add SafeAreaProvider to root layout

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -5,6 +5,7 @@ import {
 } from "@react-navigation/native";
 import { Stack } from "expo-router";
 import { StatusBar } from "expo-status-bar";
+import { SafeAreaProvider } from "react-native-safe-area-context";
 import "react-native-reanimated";
 import "../global.css";
 
@@ -14,48 +15,50 @@ export default function RootLayout() {
   const colorScheme = useColorScheme();
 
   return (
-    <ThemeProvider value={colorScheme === "dark" ? DarkTheme : DefaultTheme}>
-      <Stack
-        screenOptions={{
-          headerShown: false, // Global setting: hide ALL headers by default
-        }}
-      >
-        <Stack.Screen name="index" options={{ headerShown: false }} />
-        <Stack.Screen name="unlock" options={{ headerShown: false }} />
-        <Stack.Screen
-          name="(tabs)"
-          options={{
-            headerShown: false,
-            gestureEnabled: false, // Disable swipe back
+    <SafeAreaProvider>
+      <ThemeProvider value={colorScheme === "dark" ? DarkTheme : DefaultTheme}>
+        <Stack
+          screenOptions={{
+            headerShown: false, // Global setting: hide ALL headers by default
           }}
-        />
-        <Stack.Screen
-          name="home"
-          options={{
-            headerShown: false,
-            gestureEnabled: false, // Disable swipe back
-          }}
-        />
-        <Stack.Screen name="emergency" options={{ headerShown: false }} />
-        <Stack.Screen name="emergency-setup" options={{ headerShown: false }} />
-        <Stack.Screen name="add-credit-card" options={{ headerShown: false }} />
-        <Stack.Screen
-          name="document-details"
-          options={{ headerShown: false }}
-        />
-        <Stack.Screen name="add-document" options={{ headerShown: false }} />
-        <Stack.Screen
-          name="select-documents"
-          options={{ headerShown: false }}
-        />
-        <Stack.Screen name="profile-setup" options={{ headerShown: false }} />
-        <Stack.Screen name="change-pin" options={{ headerShown: false }} />
-        <Stack.Screen
-          name="modal"
-          options={{ presentation: "modal", title: "Modal" }}
-        />
-      </Stack>
-      <StatusBar style="light" />
-    </ThemeProvider>
+        >
+          <Stack.Screen name="index" options={{ headerShown: false }} />
+          <Stack.Screen name="unlock" options={{ headerShown: false }} />
+          <Stack.Screen
+            name="(tabs)"
+            options={{
+              headerShown: false,
+              gestureEnabled: false, // Disable swipe back
+            }}
+          />
+          <Stack.Screen
+            name="home"
+            options={{
+              headerShown: false,
+              gestureEnabled: false, // Disable swipe back
+            }}
+          />
+          <Stack.Screen name="emergency" options={{ headerShown: false }} />
+          <Stack.Screen name="emergency-setup" options={{ headerShown: false }} />
+          <Stack.Screen name="add-credit-card" options={{ headerShown: false }} />
+          <Stack.Screen
+            name="document-details"
+            options={{ headerShown: false }}
+          />
+          <Stack.Screen name="add-document" options={{ headerShown: false }} />
+          <Stack.Screen
+            name="select-documents"
+            options={{ headerShown: false }}
+          />
+          <Stack.Screen name="profile-setup" options={{ headerShown: false }} />
+          <Stack.Screen name="change-pin" options={{ headerShown: false }} />
+          <Stack.Screen
+            name="modal"
+            options={{ presentation: "modal", title: "Modal" }}
+          />
+        </Stack>
+        <StatusBar style="light" />
+      </ThemeProvider>
+    </SafeAreaProvider>
   );
 }


### PR DESCRIPTION
## What
Adds SafeAreaProvider wrapper to the root layout to properly support SafeAreaView components throughout the app.

## Why
Closes #28 - TASK-5: Substituir SafeAreaView nativo por react-native-safe-area-context

The app was missing the SafeAreaProvider wrapper in the root layout, which is required for react-native-safe-area-context to work properly and remove the deprecation warning.

## Changes
- ✅ Added SafeAreaProvider import from react-native-safe-area-context
- ✅ Wrapped entire app with SafeAreaProvider in app/_layout.tsx
- ✅ Ensures all 13 screens using SafeAreaView work correctly
- ✅ Removes deprecated SafeAreaView warning from React Native core

## Context
All screens were already migrated to use SafeAreaView from react-native-safe-area-context. This PR adds the final missing piece: the SafeAreaProvider wrapper at the root level.

## How to test
1. Run the app on iOS and Android
2. Verify no SafeAreaView deprecation warning appears in console
3. Check that safe areas are respected on:
   - iOS devices with notch/Dynamic Island
   - Android devices with system bars
4. Navigate through all screens to verify layout is correct

## Acceptance criteria checklist (Issue #28)
- [x] Nenhum SafeAreaView importado de react-native no codebase
- [x] SafeAreaView importado de react-native-safe-area-context em todos os usos
- [x] SafeAreaProvider presente na raiz da app
- [ ] Warning não aparece mais ao inicializar (needs testing)
- [ ] Layout visual correto em iOS (notch) e Android (needs testing)

## Files Changed
- `app/_layout.tsx`

## Breaking Changes
None. This is an internal improvement that enhances the existing SafeAreaView implementation.
