### PR TITLE
feat(pipeline): add Maestro heartbeat every 15 minutes

### DIFF
--- a/.github/workflows/maestro-heartbeat.yml
+++ b/.github/workflows/maestro-heartbeat.yml
@@ -1,0 +1,21 @@
+name: Maestro Heartbeat
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'  # every 15 minutes
+  workflow_dispatch:          # allow manual trigger
+
+jobs:
+  heartbeat:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping Maestro
+        run: |
+          PAYLOAD=$(jq -n \
+            --arg channel "C0AL2R8S858" \
+            --arg text "HEARTBEAT" \
+            '{channel: $channel, text: $text}')
+          curl -s -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD"


### PR DESCRIPTION
## Summary

- Adds `maestro-heartbeat.yml` workflow that runs every 15 minutes
- Sends `HEARTBEAT` message to Maestro via `#orchestrator` (C0AL2R8S858)
- Maestro checks for stuck tasks and escalates to Marcos if needed
- Supports `workflow_dispatch` for manual trigger