### PR TITLE
fix: SecureStore invalid key error during logout (issue #67)

### DIFF
--- a/src/infrastructure/storage/secure-storage-logout.integration.test.ts
+++ b/src/infrastructure/storage/secure-storage-logout.integration.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Integration tests for logout flow with SecureStorage
+ * Tests the complete logout scenario including sanitized key handling
+ */
+
+import * as SecureStore from 'expo-secure-store';
+import { SecureStorageAdapter } from './secure-storage.adapter';
+
+jest.mock('expo-secure-store', () => ({
+  setItemAsync: jest.fn(),
+  getItemAsync: jest.fn(),
+  deleteItemAsync: jest.fn(),
+}));
+
+jest.mock('react-native-mmkv', () => {
+  throw new Error('MMKV not available');
+});
+
+describe('SecureStorageAdapter - Logout Flow Integration', () => {
+  let adapter: SecureStorageAdapter;
+  const authStorageId = 'auth-storage';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    adapter = new SecureStorageAdapter(authStorageId);
+  });
+
+  describe('Real-world logout scenario', () => {
+    it('should complete logout without errors with invalid key characters', async () => {
+      // Simulate reading and storing auth tokens with colons (which are invalid for SecureStore)
+      (SecureStore.getItemAsync as jest.Mock)
+        .mockResolvedValue('auth-token-value')
+        .mockResolvedValueOnce('access-token')
+        .mockResolvedValueOnce('refresh-token')
+        .mockResolvedValueOnce('user-data');
+
+      (SecureStore.deleteItemAsync as jest.Mock).mockResolvedValue(undefined);
+
+      // Store some auth-related data with problematic key patterns
+      await adapter.set('auth:access_token', 'access-token');
+      await adapter.set('auth:refresh_token', 'refresh-token');
+      await adapter.set('user:data:profile', 'user-data');
+
+      // Retrieve to ensure backward compatibility works
+      const accessToken = await adapter.get('auth:access_token');
+      const refreshToken = await adapter.get('auth:refresh_token');
+      const userData = await adapter.get('user:data:profile');
+
+      expect(accessToken).toBeTruthy();
+      expect(refreshToken).toBeTruthy();
+      expect(userData).toBeTruthy();
+
+      // Perform logout - delete all auth keys
+      await expect(async () => {
+        await adapter.delete('auth:access_token');
+        await adapter.delete('auth:refresh_token');
+        await adapter.delete('user:data:profile');
+      }).not.toThrow();
+
+      // Verify all delete operations were called
+      expect(SecureStore.deleteItemAsync).toHaveBeenCalled();
+    });
+
+    it('should handle mixed old and new format keys during logout', async () => {
+      // Simulate a scenario where some keys are in new format (sanitized) and some in old format
+      (SecureStore.getItemAsync as jest.Mock)
+        .mockResolvedValueOnce('value1') // first get returns from sanitized key
+        .mockResolvedValueOnce('value2') // second get returns from sanitized key
+        .mockResolvedValueOnce(null) // third get sanitized not found
+        .mockResolvedValueOnce('value3'); // third get falls back to original
+
+      (SecureStore.deleteItemAsync as jest.Mock).mockResolvedValue(undefined);
+
+      // Get values (some from new format, some will migrate from old format)
+      const val1 = await adapter.get('key:with:colons:1');
+      const val2 = await adapter.get('key:with:colons:2');
+      const val3 = await adapter.get('key:with:colons:3');
+
+      expect(val1).toBe('value1');
+      expect(val2).toBe('value2');
+      expect(val3).toBe('value3'); // Auto-migrated
+
+      // Logout
+      await adapter.delete('key:with:colons:1');
+      await adapter.delete('key:with:colons:2');
+      await adapter.delete('key:with:colons:3');
+
+      // Should have deleted both sanitized and original keys for safety
+      expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('auth-storage_key_with_colons_1');
+      expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('auth-storage_key:with:colons:1');
+    });
+
+    it('should not throw if logout encounters SecureStore errors with invalid keys', async () => {
+      const consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation();
+
+      // Simulate SecureStore throwing errors on invalid keys
+      (SecureStore.deleteItemAsync as jest.Mock)
+        .mockRejectedValueOnce(new Error('Invalid key format')) // first key fails
+        .mockResolvedValueOnce(undefined) // second key succeeds
+        .mockRejectedValueOnce(new Error('Key not found')); // third key fails
+
+      // Logout should continue even if some deletes fail
+      await expect(async () => {
+        await adapter.delete('invalid::key');
+        await adapter.delete('valid_key');
+        await adapter.delete('another:bad:key');
+      }).not.toThrow();
+
+      consoleDebugSpy.mockRestore();
+    });
+  });
+
+  describe('Session cleanup with backward compatibility', () => {
+    it('should clear all auth data including legacy keys', async () => {
+      const consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation();
+
+      // Simulate finding data in old format keys
+      (SecureStore.getItemAsync as jest.Mock)
+        .mockResolvedValueOnce(null) // sanitized key not found
+        .mockResolvedValueOnce('legacy-token'); // original key found
+
+      (SecureStore.deleteItemAsync as jest.Mock).mockResolvedValue(undefined);
+
+      // Get will auto-migrate from old to new
+      const token = await adapter.get('session:token');
+      expect(token).toBe('legacy-token');
+
+      // Migration should have occurred
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith(
+        'auth-storage_session_token',
+        'legacy-token'
+      );
+      expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('auth-storage_session:token');
+
+      // Now delete during logout
+      await adapter.delete('session:token');
+
+      // Should only try new sanitized key now (old one was already deleted during migration)
+      expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('auth-storage_session_token');
+
+      consoleDebugSpy.mockRestore();
+    });
+
+    it('should handle logout when data exists only in old format', async () => {
+      (SecureStore.getItemAsync as jest.Mock)
+        .mockResolvedValueOnce(null) // sanitized key
+        .mockResolvedValueOnce('old-value'); // original key
+
+      (SecureStore.deleteItemAsync as jest.Mock).mockResolvedValue(undefined);
+
+      // Get the value (will migrate)
+      const value = await adapter.get('token:refresh');
+      expect(value).toBe('old-value');
+
+      // Delete during logout
+      await adapter.delete('token:refresh');
+
+      // Should have deleted the old key (that was found) and tried new key
+      expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('auth-storage_token_refresh');
+      expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('auth-storage_token:refresh');
+    });
+  });
+
+  describe('Large scale logout scenario', () => {
+    it('should logout multiple auth-related keys without errors', async () => {
+      (SecureStore.deleteItemAsync as jest.Mock).mockResolvedValue(undefined);
+
+      const authKeys = [
+        'auth:access_token',
+        'auth:refresh_token',
+        'auth:id_token',
+        'user:session:id',
+        'user:profile:cache',
+        'device:token:push',
+        'app:state:auth_status',
+        'cache:user_preferences',
+      ];
+
+      // Logout all keys
+      for (const key of authKeys) {
+        await adapter.delete(key);
+      }
+
+      // Each key attempts to delete both sanitized and original
+      // Expected calls: authKeys.length * 2 (since each is different from original)
+      expect(SecureStore.deleteItemAsync).toHaveBeenCalledTimes(authKeys.length * 2);
+
+      // Verify specific keys were called with sanitized versions
+      expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('auth-storage_auth_access_token');
+      expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('auth-storage_user_session_id');
+      expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('auth-storage_device_token_push');
+    });
+
+    it('should handle partial failures during bulk logout', async () => {
+      const consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation();
+
+      (SecureStore.deleteItemAsync as jest.Mock)
+        .mockResolvedValue(undefined)
+        .mockRejectedValueOnce(new Error('Storage error')) // First call fails
+        .mockResolvedValue(undefined); // Rest succeed
+
+      const authKeys = [
+        'auth:token1',
+        'auth:token2',
+        'auth:token3',
+      ];
+
+      // Should not throw even with failures
+      for (const key of authKeys) {
+        await expect(adapter.delete(key)).resolves.toBeUndefined();
+      }
+
+      expect(consoleDebugSpy).toHaveBeenCalled();
+      consoleDebugSpy.mockRestore();
+    });
+  });
+
+  describe('Re-authentication after logout', () => {
+    it('should allow new data storage after logout', async () => {
+      (SecureStore.setItemAsync as jest.Mock).mockResolvedValue(undefined);
+      (SecureStore.getItemAsync as jest.Mock).mockResolvedValue(null);
+      (SecureStore.deleteItemAsync as jest.Mock).mockResolvedValue(undefined);
+
+      // Logout
+      await adapter.delete('auth:token');
+
+      // Should be able to store new token
+      await adapter.set('auth:token', 'new-token-value');
+
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith(
+        'auth-storage_auth_token',
+        'new-token-value'
+      );
+
+      // And retrieve it
+      (SecureStore.getItemAsync as jest.Mock).mockResolvedValueOnce('new-token-value');
+
+      const token = await adapter.get('auth:token');
+      expect(token).toBe('new-token-value');
+    });
+
+    it('should not have any residual old keys after logout and re-auth', async () => {
+      (SecureStore.setItemAsync as jest.Mock).mockResolvedValue(undefined);
+      (SecureStore.getItemAsync as jest.Mock).mockResolvedValue(null);
+      (SecureStore.deleteItemAsync as jest.Mock).mockResolvedValue(undefined);
+
+      // Initial logout
+      await adapter.delete('user:data');
+
+      // Both old and new format keys should have been deleted
+      expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('auth-storage_user_data');
+      expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('auth-storage_user:data');
+
+      // Re-authenticate with new data
+      await adapter.set('user:data', 'new-profile');
+
+      // New data should only use sanitized key
+      expect(SecureStore.setItemAsync).toHaveBeenLastCalledWith(
+        'auth-storage_user_data',
+        'new-profile'
+      );
+    });
+  });
+
+  describe('Error recovery during logout', () => {
+    it('should continue logout process even if some keys fail to delete', async () => {
+      const consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation();
+
+      // Simulate alternating success/failure pattern
+      (SecureStore.deleteItemAsync as jest.Mock)
+        .mockResolvedValueOnce(undefined) // key1 sanitized - ok
+        .mockRejectedValueOnce(new Error('Fail')) // key1 original - fail
+        .mockResolvedValueOnce(undefined) // key2 sanitized - ok
+        .mockResolvedValueOnce(undefined) // key2 original - ok
+        .mockRejectedValueOnce(new Error('Fail')); // key3 sanitized - fail
+
+      const keys = ['key:1', 'key:2', 'key:3'];
+
+      // Should not throw, continue with all deletes
+      for (const key of keys) {
+        await expect(adapter.delete(key)).resolves.toBeUndefined();
+      }
+
+      // All delete attempts should have been made (each key attempts both sanitized and original)
+      expect(SecureStore.deleteItemAsync).toHaveBeenCalledTimes(6);
+
+      consoleDebugSpy.mockRestore();
+    });
+
+    it('should log debug messages for failed operations', async () => {
+      const consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation();
+
+      (SecureStore.deleteItemAsync as jest.Mock).mockRejectedValue(new Error('Delete failed'));
+
+      await adapter.delete('session:token');
+
+      expect(consoleDebugSpy).toHaveBeenCalled();
+      expect(consoleDebugSpy.mock.calls.some(call =>
+        call[0].includes('Failed to delete')
+      )).toBe(true);
+
+      consoleDebugSpy.mockRestore();
+    });
+  });
+});

--- a/src/infrastructure/storage/secure-storage.adapter.test.ts
+++ b/src/infrastructure/storage/secure-storage.adapter.test.ts
@@ -1,0 +1,448 @@
+import * as SecureStore from 'expo-secure-store';
+import { SecureStorageAdapter } from './secure-storage.adapter';
+
+// Mock expo-secure-store
+jest.mock('expo-secure-store', () => ({
+  setItemAsync: jest.fn(),
+  getItemAsync: jest.fn(),
+  deleteItemAsync: jest.fn(),
+}));
+
+// Mock react-native-mmkv to ensure we test SecureStore path
+jest.mock('react-native-mmkv', () => {
+  throw new Error('MMKV not available');
+});
+
+describe('SecureStorageAdapter', () => {
+  let adapter: SecureStorageAdapter;
+  const storageId = 'test-storage';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    adapter = new SecureStorageAdapter(storageId);
+  });
+
+  describe('Key Sanitization', () => {
+    it('should sanitize invalid characters in keys', async () => {
+      const keyWithInvalidChars = 'user:profile:data';
+      const expectedSanitizedKey = 'test-storage_user_profile_data';
+
+      await adapter.set(keyWithInvalidChars, 'value');
+
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith(expectedSanitizedKey, 'value');
+    });
+
+    it('should replace colons with underscores', async () => {
+      const keyWithColons = 'auth:token:refresh';
+      const expectedKey = 'test-storage_auth_token_refresh';
+
+      await adapter.set(keyWithColons, 'token123');
+
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith(expectedKey, 'token123');
+    });
+
+    it('should replace special characters with underscores', async () => {
+      const keyWithSpecialChars = 'user@domain#123$key%special';
+      const expectedKey = 'test-storage_user_domain_123_key_special';
+
+      await adapter.set(keyWithSpecialChars, 'value');
+
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith(expectedKey, 'value');
+    });
+
+    it('should allow valid characters (alphanumeric, dots, hyphens, underscores)', async () => {
+      const validKey = 'user.profile-data_123';
+      const expectedKey = `${storageId}_${validKey}`;
+
+      await adapter.set(validKey, 'value');
+
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith(expectedKey, 'value');
+    });
+
+    it('should handle keys with spaces', async () => {
+      const keyWithSpaces = 'user data key';
+      const expectedKey = 'test-storage_user_data_key';
+
+      await adapter.set(keyWithSpaces, 'value');
+
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith(expectedKey, 'value');
+    });
+
+    it('should handle keys with slashes', async () => {
+      const keyWithSlashes = 'user/profile/data';
+      const expectedKey = 'test-storage_user_profile_data';
+
+      await adapter.set(keyWithSlashes, 'value');
+
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith(expectedKey, 'value');
+    });
+
+    it('should handle keys with commas', async () => {
+      const keyWithCommas = 'item1,item2,item3';
+      const expectedKey = 'test-storage_item1_item2_item3';
+
+      await adapter.set(keyWithCommas, 'value');
+
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith(expectedKey, 'value');
+    });
+  });
+
+  describe('Set Operation', () => {
+    it('should set value with sanitized key', async () => {
+      await adapter.set('auth:token', 'secret123');
+
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith(
+        'test-storage_auth_token',
+        'secret123'
+      );
+    });
+
+    it('should handle empty values', async () => {
+      await adapter.set('empty:key', '');
+
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith('test-storage_empty_key', '');
+    });
+
+    it('should handle large values', async () => {
+      const largeValue = 'x'.repeat(10000);
+      await adapter.set('large:data', largeValue);
+
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith(
+        'test-storage_large_data',
+        largeValue
+      );
+    });
+
+    it('should handle special characters in values', async () => {
+      const specialValue = 'value:with@special#chars$123';
+      await adapter.set('key', specialValue);
+
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith('test-storage_key', specialValue);
+    });
+  });
+
+  describe('Backward Compatibility', () => {
+    it('should try sanitized key first', async () => {
+      (SecureStore.getItemAsync as jest.Mock).mockResolvedValueOnce('found-value');
+
+      const result = await adapter.get('user:profile');
+
+      expect(SecureStore.getItemAsync).toHaveBeenCalledWith('test-storage_user_profile');
+      expect(result).toBe('found-value');
+    });
+
+    it('should fallback to original key if sanitized key not found', async () => {
+      const originalKey = 'test-storage_user:profile';
+      const sanitizedKey = 'test-storage_user_profile';
+
+      (SecureStore.getItemAsync as jest.Mock)
+        .mockResolvedValueOnce(null) // First call with sanitized key returns null
+        .mockResolvedValueOnce('old-value'); // Second call with original key returns value
+
+      const result = await adapter.get('user:profile');
+
+      expect(SecureStore.getItemAsync).toHaveBeenNthCalledWith(1, sanitizedKey);
+      expect(SecureStore.getItemAsync).toHaveBeenNthCalledWith(2, originalKey);
+      expect(result).toBe('old-value');
+    });
+
+    it('should not try original key if keys are identical', async () => {
+      const validKey = 'userprofile';
+
+      (SecureStore.getItemAsync as jest.Mock).mockResolvedValueOnce(null);
+
+      await adapter.get(validKey);
+
+      // Should only call once since sanitized and original are the same
+      expect(SecureStore.getItemAsync).toHaveBeenCalledTimes(1);
+      expect(SecureStore.getItemAsync).toHaveBeenCalledWith('test-storage_userprofile');
+    });
+
+    it('should return null if neither key exists', async () => {
+      (SecureStore.getItemAsync as jest.Mock).mockResolvedValue(null);
+
+      const result = await adapter.get('user:profile');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('Auto-Migration', () => {
+    it('should migrate data from original key to sanitized key on read', async () => {
+      const originalKey = 'test-storage_user:profile';
+      const sanitizedKey = 'test-storage_user_profile';
+      const oldValue = 'old-value';
+
+      (SecureStore.getItemAsync as jest.Mock)
+        .mockResolvedValueOnce(null) // sanitized key not found
+        .mockResolvedValueOnce(oldValue); // original key found
+
+      await adapter.get('user:profile');
+
+      // Should migrate: set sanitized, delete original
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith(sanitizedKey, oldValue);
+      expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith(originalKey);
+    });
+
+    it('should not attempt migration if value not found in original key', async () => {
+      (SecureStore.getItemAsync as jest.Mock).mockResolvedValue(null);
+
+      await adapter.get('user:profile');
+
+      // Should not call set or delete if value is null
+      expect(SecureStore.setItemAsync).not.toHaveBeenCalled();
+      expect(SecureStore.deleteItemAsync).not.toHaveBeenCalled();
+    });
+
+    it('should handle errors during original key read gracefully', async () => {
+      const consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation();
+
+      (SecureStore.getItemAsync as jest.Mock)
+        .mockResolvedValueOnce(null) // sanitized key
+        .mockRejectedValueOnce(new Error('Invalid key')); // original key throws
+
+      const result = await adapter.get('user:profile');
+
+      expect(result).toBeNull();
+      expect(consoleDebugSpy).toHaveBeenCalled();
+      consoleDebugSpy.mockRestore();
+    });
+  });
+
+  describe('Delete Operation', () => {
+    it('should delete using sanitized key', async () => {
+      await adapter.delete('user:profile');
+
+      expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('test-storage_user_profile');
+    });
+
+    it('should attempt to delete both original and sanitized keys', async () => {
+      (SecureStore.deleteItemAsync as jest.Mock)
+        .mockResolvedValueOnce(undefined) // sanitized key
+        .mockResolvedValueOnce(undefined); // original key
+
+      await adapter.delete('user:profile');
+
+      expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('test-storage_user_profile');
+      expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('test-storage_user:profile');
+    });
+
+    it('should not attempt to delete original key if keys are identical', async () => {
+      (SecureStore.deleteItemAsync as jest.Mock).mockResolvedValue(undefined);
+
+      await adapter.delete('userprofile');
+
+      // Should only call once
+      expect(SecureStore.deleteItemAsync).toHaveBeenCalledTimes(1);
+      expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('test-storage_userprofile');
+    });
+
+    it('should handle errors during delete gracefully', async () => {
+      const consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation();
+
+      (SecureStore.deleteItemAsync as jest.Mock).mockRejectedValue(new Error('Delete failed'));
+
+      // Should not throw
+      await expect(adapter.delete('user:profile')).resolves.toBeUndefined();
+      expect(consoleDebugSpy).toHaveBeenCalled();
+
+      consoleDebugSpy.mockRestore();
+    });
+
+    it('should handle partial delete failures (sanitized ok, original fails)', async () => {
+      const consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation();
+
+      (SecureStore.deleteItemAsync as jest.Mock)
+        .mockResolvedValueOnce(undefined) // sanitized key succeeds
+        .mockRejectedValueOnce(new Error('Original key invalid')); // original key fails
+
+      await adapter.delete('user:profile');
+
+      expect(SecureStore.deleteItemAsync).toHaveBeenCalledTimes(2);
+      consoleDebugSpy.mockRestore();
+    });
+  });
+
+  describe('Logout Flow', () => {
+    it('should complete logout without errors when deleting auth tokens', async () => {
+      (SecureStore.deleteItemAsync as jest.Mock).mockResolvedValue(undefined);
+
+      // Simulate logout clearing multiple auth-related keys
+      await adapter.delete('auth:token');
+      await adapter.delete('auth:refresh_token');
+      await adapter.delete('user:session');
+
+      expect(SecureStore.deleteItemAsync).toHaveBeenCalledTimes(6); // 2 deletes per key (sanitized + original)
+      expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('test-storage_auth_token');
+      expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('test-storage_auth:token');
+      expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('test-storage_auth_refresh_token');
+      expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('test-storage_auth:refresh_token');
+    });
+
+    it('should handle logout with pre-existing invalid keys', async () => {
+      const consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation();
+
+      (SecureStore.deleteItemAsync as jest.Mock)
+        .mockResolvedValueOnce(undefined) // sanitized key
+        .mockRejectedValueOnce(new Error('Invalid key format')); // original key fails
+
+      // Should not throw during logout
+      await expect(adapter.delete('user:session')).resolves.toBeUndefined();
+
+      consoleDebugSpy.mockRestore();
+    });
+
+    it('should clear all data successfully', async () => {
+      (SecureStore.deleteItemAsync as jest.Mock).mockResolvedValue(undefined);
+
+      await adapter.clear();
+
+      // clear() uses MMKV fallback path, but in our test MMKV is disabled
+      // So it just does nothing, which is expected behavior
+    });
+  });
+
+  describe('Integration Scenarios', () => {
+    it('should handle set then get sequence with sanitized keys', async () => {
+      (SecureStore.getItemAsync as jest.Mock).mockResolvedValueOnce('stored-value');
+
+      await adapter.set('user:data:profile', 'profile-json');
+      const result = await adapter.get('user:data:profile');
+
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith(
+        'test-storage_user_data_profile',
+        'profile-json'
+      );
+      expect(result).toBe('stored-value');
+    });
+
+    it('should handle update sequence (set, get, delete)', async () => {
+      (SecureStore.getItemAsync as jest.Mock)
+        .mockResolvedValueOnce('initial-value')
+        .mockResolvedValueOnce('updated-value');
+
+      await adapter.set('config:app:theme', 'dark');
+      const value1 = await adapter.get('config:app:theme');
+      await adapter.delete('config:app:theme');
+      const value2 = await adapter.get('config:app:theme');
+
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith(
+        'test-storage_config_app_theme',
+        'dark'
+      );
+      expect(value1).toBe('initial-value');
+      expect(value2).toBe('updated-value');
+      expect(SecureStore.deleteItemAsync).toHaveBeenCalled();
+    });
+
+    it('should handle multiple keys with similar patterns', async () => {
+      (SecureStore.getItemAsync as jest.Mock).mockResolvedValue('value');
+
+      await adapter.set('user:session:token', 'token1');
+      await adapter.set('user:session:refresh', 'token2');
+      await adapter.get('user:session:token');
+      await adapter.get('user:session:refresh');
+
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith(
+        'test-storage_user_session_token',
+        'token1'
+      );
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith(
+        'test-storage_user_session_refresh',
+        'token2'
+      );
+    });
+
+    it('should handle concurrent operations', async () => {
+      (SecureStore.getItemAsync as jest.Mock).mockResolvedValue('value');
+
+      await Promise.all([
+        adapter.set('key1', 'value1'),
+        adapter.set('key2', 'value2'),
+        adapter.get('key3'),
+        adapter.delete('key4'),
+      ]);
+
+      expect(SecureStore.setItemAsync).toHaveBeenCalledTimes(2);
+      expect(SecureStore.getItemAsync).toHaveBeenCalledTimes(1);
+      expect(SecureStore.deleteItemAsync).toHaveBeenCalled();
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should handle keys that are entirely special characters', async () => {
+      await adapter.set('::://@@@###', 'value');
+
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith('test-storage____________', 'value');
+    });
+
+    it('should handle very long keys', async () => {
+      const longKey = 'a'.repeat(500) + ':' + 'b'.repeat(500);
+      await adapter.set(longKey, 'value');
+
+      const expectedKey = `${storageId}_${longKey.replace(/[^a-zA-Z0-9._-]/g, '_')}`;
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith(expectedKey, 'value');
+    });
+
+    it('should handle keys with mixed valid and invalid characters', async () => {
+      const mixedKey = 'user_123:profile-data@v2.0';
+      const expectedKey = 'test-storage_user_123_profile-data_v2.0';
+
+      await adapter.set(mixedKey, 'value');
+
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith(expectedKey, 'value');
+    });
+
+    it('should handle empty string key', async () => {
+      await adapter.set('', 'value');
+
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith('test-storage_', 'value');
+    });
+
+    it('should handle different storage IDs with same key', async () => {
+      const adapter1 = new SecureStorageAdapter('storage1');
+      const adapter2 = new SecureStorageAdapter('storage2');
+
+      await adapter1.set('user:data', 'value1');
+      await adapter2.set('user:data', 'value2');
+
+      expect(SecureStore.setItemAsync).toHaveBeenNthCalledWith(1, 'storage1_user_data', 'value1');
+      expect(SecureStore.setItemAsync).toHaveBeenNthCalledWith(2, 'storage2_user_data', 'value2');
+    });
+  });
+
+  describe('Character Whitelist', () => {
+    it('should preserve alphanumeric characters', async () => {
+      await adapter.set('abc123XYZ', 'value');
+
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith('test-storage_abc123XYZ', 'value');
+    });
+
+    it('should preserve dots', async () => {
+      await adapter.set('user.profile.data', 'value');
+
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith(
+        'test-storage_user.profile.data',
+        'value'
+      );
+    });
+
+    it('should preserve hyphens', async () => {
+      await adapter.set('user-profile-data', 'value');
+
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith(
+        'test-storage_user-profile-data',
+        'value'
+      );
+    });
+
+    it('should preserve underscores', async () => {
+      await adapter.set('user_profile_data', 'value');
+
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith(
+        'test-storage_user_profile_data',
+        'value'
+      );
+    });
+  });
+});

--- a/src/infrastructure/storage/secure-storage.adapter.ts
+++ b/src/infrastructure/storage/secure-storage.adapter.ts
@@ -29,33 +29,77 @@ export class SecureStorageAdapter {
     }
   }
 
-  async set(key: string, value: string): Promise<void> {
+  private sanitizeKeyForSecureStore(key: string): string {
+    // SecureStore requires keys to contain only alphanumeric characters, ".", "-", and "_"
+    // Replace any invalid characters with "_"
+    return key.replace(/[^a-zA-Z0-9._-]/g, '_');
+  }
+
+  private getSecureStoreKeys(key: string): { original: string; sanitized: string } {
     const storageKey = `${this.storageId}_${key}`;
-    
+    const sanitizedKey = this.sanitizeKeyForSecureStore(storageKey);
+    return { original: storageKey, sanitized: sanitizedKey };
+  }
+
+  async set(key: string, value: string): Promise<void> {
     if (this.mmkvInstance) {
       this.mmkvInstance.set(key, value);
     } else {
-      await SecureStore.setItemAsync(storageKey, value);
+      const { sanitized } = this.getSecureStoreKeys(key);
+      await SecureStore.setItemAsync(sanitized, value);
     }
   }
 
   async get(key: string): Promise<string | null> {
-    const storageKey = `${this.storageId}_${key}`;
-    
     if (this.mmkvInstance) {
       return this.mmkvInstance.getString(key) || null;
     } else {
-      return await SecureStore.getItemAsync(storageKey);
+      const { original, sanitized } = this.getSecureStoreKeys(key);
+      
+      // Try sanitized key first (new format)
+      let value = await SecureStore.getItemAsync(sanitized);
+      
+      // If not found and keys are different, try original key for backward compatibility
+      if (value === null && original !== sanitized) {
+        try {
+          value = await SecureStore.getItemAsync(original);
+          // If found with original key, migrate to sanitized key
+          if (value !== null) {
+            await SecureStore.setItemAsync(sanitized, value);
+            await SecureStore.deleteItemAsync(original);
+          }
+        } catch (error) {
+          // Original key might be invalid for SecureStore, ignore and return null
+          console.debug('Failed to read with original key, likely invalid characters:', error);
+        }
+      }
+      
+      return value;
     }
   }
 
   async delete(key: string): Promise<void> {
-    const storageKey = `${this.storageId}_${key}`;
-    
     if (this.mmkvInstance) {
       this.mmkvInstance.delete(key);
     } else {
-      await SecureStore.deleteItemAsync(storageKey);
+      const { original, sanitized } = this.getSecureStoreKeys(key);
+      
+      // Try to delete with both keys to ensure cleanup
+      try {
+        await SecureStore.deleteItemAsync(sanitized);
+      } catch (error) {
+        console.debug('Failed to delete with sanitized key:', error);
+      }
+      
+      // Also try original key for backward compatibility
+      if (original !== sanitized) {
+        try {
+          await SecureStore.deleteItemAsync(original);
+        } catch (error) {
+          // Original key might be invalid for SecureStore, ignore
+          console.debug('Failed to delete with original key, likely invalid characters:', error);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Closes #67

Fixes logout error caused by invalid characters in SecureStore keys. Storage keys containing colons (:) are now sanitized automatically. The SecureStorageAdapter handles backward compatibility by trying both original and sanitized keys, and automatically migrates data.