### PR TITLE
chore: close issues automatically when PR is merged

### DIFF
--- a/.github/workflows/close-issues-on-merge.yml
+++ b/.github/workflows/close-issues-on-merge.yml
@@ -1,0 +1,23 @@
+name: Close Issues on PR Merge
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  close-issues:
+    name: Close linked issues
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+
+    steps:
+      - name: Close issues referenced in PR body
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          REPO: ${{ github.repository }}
+        run: |
+          echo "$PR_BODY" | grep -oiE '(closes|fixes|resolves) #[0-9]+' | grep -oE '[0-9]+' | while read issue; do
+            echo "Closing issue #$issue"
+            gh issue close "$issue" --repo "$REPO" --comment "Closed by PR #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}"
+          done


### PR DESCRIPTION
**What:** Adds a GitHub Actions workflow that closes issues referenced with `Closes #N`, `Fixes #N` or `Resolves #N` in PR bodies, regardless of which branch the PR targets.

**Why:** GitHub's native auto-close only works when merging into the default branch (`main`). Our pipeline merges into `develop_bot` → `develop`, so issues were staying open after merge.

**How it works:** On every merged PR, the workflow parses the PR body, extracts issue numbers, and closes them via `gh issue close`.