### PR TITLE
fix: restaurar layout de row em Profile de Settings (Task #104)

### DIFF
--- a/src/presentation/components/user-avatar.tsx
+++ b/src/presentation/components/user-avatar.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { View, Image, Pressable, ActivityIndicator, Text } from 'react-native';
+
+interface UserAvatarProps {
+  photoUri?: string | null;
+  size?: number;
+  onPress?: () => void;
+  isLoading?: boolean;
+}
+
+export function UserAvatar({
+  photoUri,
+  size = 64,
+  onPress,
+  isLoading = false,
+}: UserAvatarProps) {
+  const Container = onPress ? Pressable : View;
+  
+  return (
+    <Container
+      onPress={onPress}
+      className="rounded-full overflow-hidden border-2 border-primary-main/30"
+      style={{ width: size, height: size }}
+    >
+      {photoUri ? (
+        <Image
+          source={{ uri: photoUri }}
+          className="w-full h-full"
+          style={{ resizeMode: 'cover' }}
+        />
+      ) : (
+        <View className="w-full h-full bg-primary-main/20 items-center justify-center">
+          <Text className="text-3xl">👤</Text>
+        </View>
+      )}
+      
+      {isLoading && (
+        <View className="absolute inset-0 bg-black/50 items-center justify-center">
+          <ActivityIndicator color="white" />
+          <Text className="text-white text-xs mt-1">Loading...</Text>
+        </View>
+      )}
+    </Container>
+  );
+}

--- a/src/presentation/screens/profile-setup-screen.tsx
+++ b/src/presentation/screens/profile-setup-screen.tsx
@@ -1,14 +1,36 @@
-import { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { View, Text, TextInput, Pressable, ActivityIndicator, Alert } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useRouter } from 'expo-router';
+import { useRouter, useFocusEffect } from 'expo-router';
 import { useUserProfile } from '@presentation/hooks/use-user-profile';
+import { useProfilePhoto } from '@presentation/hooks/use-profile-photo';
+import { UserAvatar } from '@presentation/components/user-avatar';
 
 export function ProfileSetupScreen() {
   const router = useRouter();
-  const { saveProfile } = useUserProfile();
+  const [photoUri, setPhotoUri] = useState<string | null>(null);
+  const { profile, saveProfile, reloadProfile } = useUserProfile();
+  const { pickImage, isLoading: isPhotoLoading } = useProfilePhoto(reloadProfile);
   const [name, setName] = useState('');
-  const [isLoading, setIsLoading] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+
+  useFocusEffect(
+    React.useCallback(() => {
+      reloadProfile();
+    }, [])
+  );
+
+  useEffect(() => {
+    if (profile?.photoUri) {
+      setPhotoUri(profile.photoUri);
+    }
+  }, [profile?.photoUri]);
+
+  useEffect(() => {
+    if (profile?.name) {
+      setName(profile.name);
+    }
+  }, [profile]);
 
   const handleSave = async () => {
     if (name.trim().length < 2) {
@@ -16,30 +38,72 @@ export function ProfileSetupScreen() {
       return;
     }
 
-    setIsLoading(true);
+    setIsSaving(true);
     const result = await saveProfile({ name: name.trim() });
-    setIsLoading(false);
+    setIsSaving(false);
 
     if (result.success) {
-      // Navigate to main app after profile setup
-      router.replace('/(tabs)');
+      // Use router.canGoBack() to decide navigation
+      if (router.canGoBack()) {
+        router.back();
+      } else {
+        router.replace('/(tabs)');
+      }
     } else {
       Alert.alert('Error', result.message);
     }
   };
 
+  const handleSelectPhoto = async () => {
+    Alert.alert(
+      'Choose Profile Photo',
+      'Select an option to choose your profile photo',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        { 
+          text: 'Take Photo', 
+          onPress: async () => {
+            const newPhotoUri = await pickImage('camera');
+            if (newPhotoUri) {
+              setPhotoUri(newPhotoUri);
+            }
+          }
+        },
+        { 
+          text: 'Choose from Gallery', 
+          onPress: async () => {
+            const newPhotoUri = await pickImage('gallery');
+            if (newPhotoUri) {
+              setPhotoUri(newPhotoUri);
+            }
+          }
+        },
+      ]
+    );
+  };
+
   return (
     <SafeAreaView className="flex-1 bg-background-primary px-6" edges={['top']}>
       <View className="flex-1 justify-center">
-        <View className="items-center mb-8">
-          <View className="w-24 h-24 bg-primary-main/20 rounded-full items-center justify-center mb-6">
-            <Text className="text-5xl">👤</Text>
-          </View>
-          <Text className="text-2xl font-bold text-text-primary mb-2">Welcome to Thoryx</Text>
-          <Text className="text-base text-text-secondary text-center">
-            Let&apos;s set up your profile to get started
-          </Text>
+        <View className="items-center mb-6">
+          <UserAvatar 
+            photoUri={photoUri}
+            size={80}
+            onPress={handleSelectPhoto}
+          />
+          <Pressable onPress={handleSelectPhoto} className="mt-3">
+            <Text className="text-sm text-primary-main font-semibold">
+              {photoUri ? 'Alterar imagem' : 'Escolher imagem'}
+            </Text>
+          </Pressable>
         </View>
+
+        <Text className="text-2xl font-bold text-text-primary mb-2 text-center">
+          {profile ? 'Edit Profile' : 'Welcome to Thoryx'}
+        </Text>
+        <Text className="text-base text-text-secondary text-center mb-8">
+          {profile ? 'Update your profile information' : 'Let&apos;s set up your profile to get started'}
+        </Text>
 
         <View className="mb-6">
           <Text className="text-sm font-semibold text-text-secondary mb-2">YOUR NAME</Text>
@@ -49,20 +113,20 @@ export function ProfileSetupScreen() {
             placeholderTextColor="#9CA3AF"
             value={name}
             onChangeText={setName}
-            autoFocus
-            editable={!isLoading}
+            autoFocus={!profile?.name}
+            editable={!isSaving && !isPhotoLoading}
           />
         </View>
 
         <Pressable
-          className={`bg-primary-main rounded-xl py-4 items-center ${isLoading ? 'opacity-50' : 'active:opacity-80'}`}
+          className={`bg-primary-main rounded-xl py-4 items-center ${isSaving ? 'opacity-50' : 'active:opacity-80'}`}
           onPress={handleSave}
-          disabled={isLoading}
+          disabled={isSaving || isPhotoLoading}
         >
-          {isLoading ? (
+          {isSaving ? (
             <ActivityIndicator color="#FFFFFF" />
           ) : (
-            <Text className="text-white font-bold text-base">Continue</Text>
+            <Text className="text-white font-bold text-base">{profile ? 'Save Changes' : 'Continue'}</Text>
           )}
         </Pressable>
       </View>

--- a/src/presentation/screens/settings-screen.tsx
+++ b/src/presentation/screens/settings-screen.tsx
@@ -1,12 +1,12 @@
-import { View, Text, ScrollView, Pressable, Alert, Image } from 'react-native';
+import { View, Text, ScrollView, Pressable, Alert } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useState, useEffect } from 'react';
-import { useRouter } from 'expo-router';
+import React, { useState, useEffect } from 'react';
+import { useRouter, useFocusEffect } from 'expo-router';
 import { useUserProfile } from '@presentation/hooks/use-user-profile';
 import { useBiometry } from '@presentation/hooks/use-biometry';
-import { useProfilePhoto } from '@presentation/hooks/use-profile-photo';
 import { SettingsSection } from '@presentation/components/settings-section';
 import { SettingsItem } from '@presentation/components/settings-item';
+import { UserAvatar } from '@presentation/components/user-avatar';
 import { SecureStorageAdapter } from '@infrastructure/storage/secure-storage.adapter';
 import { AuthService } from '@infrastructure/services/auth.service';
 import { APP_CONFIG } from '@shared/constants/app';
@@ -18,10 +18,15 @@ export function SettingsScreen() {
   const router = useRouter();
   const { profile, reloadProfile } = useUserProfile();
   const { isAvailable: biometryAvailable, getBiometryName, authenticate } = useBiometry();
-  const { showImagePickerOptions, isLoading: isPhotoLoading } = useProfilePhoto(reloadProfile);
   const [biometricEnabled, setBiometricEnabled] = useState(false);
   const [autoLockTimeout, setAutoLockTimeout] = useState('5 minutes');
   const [isLoggingOut, setIsLoggingOut] = useState(false);
+
+  useFocusEffect(
+    React.useCallback(() => {
+      reloadProfile();
+    }, [])
+  );
 
   useEffect(() => {
     loadBiometryPreference();
@@ -159,8 +164,6 @@ export function SettingsScreen() {
     );
   };
 
-
-
   const handleTermsOfService = () => {
     router.push('/terms-of-service');
   };
@@ -168,6 +171,8 @@ export function SettingsScreen() {
   const handlePrivacyPolicy = () => {
     router.push('/privacy-policy');
   };
+
+
 
   return (
     <SafeAreaView className="flex-1 bg-background-primary" edges={['top']}>
@@ -179,54 +184,14 @@ export function SettingsScreen() {
 
           {/* Profile Section */}
           <SettingsSection title="PROFILE">
-            <Pressable
-              onPress={() => router.push('/profile-setup')}
-              className="p-4 active:bg-surface-hover"
-            >
-              <View className="flex-row items-center">
-                <View className="items-center mr-4">
-                  <Pressable
-                    onPress={(e) => {
-                      e.stopPropagation();
-                      showImagePickerOptions();
-                    }}
-                    disabled={isPhotoLoading}
-                    className="relative"
-                  >
-                    <View className="w-16 h-16 md:w-20 md:h-20 rounded-full overflow-hidden border-2 border-primary-main/30">
-                      {profile?.photoUri ? (
-                        <Image
-                          source={{ uri: profile.photoUri }}
-                          className="w-full h-full"
-                          resizeMode="cover"
-                        />
-                      ) : (
-                        <View className="w-full h-full bg-primary-main/20 items-center justify-center">
-                          <Text className="text-3xl md:text-4xl">👤</Text>
-                        </View>
-                      )}
-                      {isPhotoLoading && (
-                        <View className="absolute inset-0 bg-black/50 items-center justify-center">
-                          <Text className="text-white text-sm">Loading...</Text>
-                        </View>
-                      )}
-                    </View>
-                  </Pressable>
-                  <Text className="text-xs text-center mt-1 text-primary-main font-medium">
-                    {profile?.photoUri ? 'Alterar imagem' : 'Escolher imagem'}
-                  </Text>
-                </View>
-                <View className="flex-1">
-                  <Text className="text-lg md:text-xl font-bold text-text-primary mb-1">
-                    {profile?.name || 'Set up profile'}
-                  </Text>
-                  <Text className="text-sm md:text-base text-text-secondary">
-                    Tap to edit profile
-                  </Text>
-                </View>
-                <Text className="text-text-secondary text-xl">›</Text>
-              </View>
-            </Pressable>
+            <View className="items-center py-4 border-b border-gray-200">
+              <UserAvatar 
+                photoUri={profile?.photoUri}
+                size={64}
+                onPress={() => router.push('/profile-setup')}
+              />
+              <Text className="mt-3 font-semibold">{profile?.name || 'Sem nome'}</Text>
+            </View>
           </SettingsSection>
 
           {/* Security Section */}

--- a/src/presentation/screens/settings-screen.tsx
+++ b/src/presentation/screens/settings-screen.tsx
@@ -184,14 +184,29 @@ export function SettingsScreen() {
 
           {/* Profile Section */}
           <SettingsSection title="PROFILE">
-            <View className="items-center py-4 border-b border-gray-200">
-              <UserAvatar 
-                photoUri={profile?.photoUri}
-                size={64}
-                onPress={() => router.push('/profile-setup')}
-              />
-              <Text className="mt-3 font-semibold">{profile?.name || 'Sem nome'}</Text>
-            </View>
+            <Pressable
+              onPress={() => router.push("/profile-setup")}
+              className="p-4 active:bg-surface-hover"
+            >
+              <View className="flex-row items-center">
+                <View className="mr-4">
+                  <UserAvatar
+                    photoUri={profile?.photoUri}
+                    size={64}
+                    onPress={() => router.push("/profile-setup")}
+                  />
+                </View>
+                <View className="flex-1">
+                  <Text className="text-lg md:text-xl font-bold text-text-primary mb-1">
+                    {profile?.name || "Set up profile"}
+                  </Text>
+                  <Text className="text-sm md:text-base text-text-secondary">
+                    Tap to edit profile
+                  </Text>
+                </View>
+                <Text className="text-text-secondary text-xl">›</Text>
+              </View>
+            </Pressable>
           </SettingsSection>
 
           {/* Security Section */}

--- a/src/presentation/screens/terms-of-service-screen.tsx
+++ b/src/presentation/screens/terms-of-service-screen.tsx
@@ -85,7 +85,7 @@ export function TermsOfServiceScreen() {
               5. No Warranty
             </Text>
             <Text className="text-base md:text-lg text-text-secondary leading-relaxed">
-              Thoryx is provided "as is" without warranty of any kind. We do not guarantee uninterrupted or error-free operation.
+              Thoryx is provided &ldquo;as is&rdquo; without warranty of any kind. We do not guarantee uninterrupted or error-free operation.
             </Text>
           </View>
 

--- a/src/presentation/screens/wallet-home-screen.tsx
+++ b/src/presentation/screens/wallet-home-screen.tsx
@@ -1,13 +1,13 @@
 import { ActionCard } from "@presentation/components/action-card";
 import { SvgIcon } from "@presentation/components/svg-icon";
+import { UserAvatar } from "@presentation/components/user-avatar";
 import { useCreditCards } from "@presentation/hooks/use-credit-cards";
 import { useDocuments } from "@presentation/hooks/use-documents";
 import { useUserProfile } from "@presentation/hooks/use-user-profile";
-import { useRouter } from "expo-router";
-import { useEffect } from "react";
+import { useRouter, useFocusEffect } from "expo-router";
+import React, { useEffect } from "react";
 import {
   ActivityIndicator,
-  Image,
   Pressable,
   ScrollView,
   Text,
@@ -19,9 +19,15 @@ export function WalletHomeScreen() {
   const router = useRouter();
   const { documents, isLoading: documentsLoading } = useDocuments();
   const { cards, isLoading: cardsLoading } = useCreditCards();
-  const { profile, isLoading: profileLoading } = useUserProfile();
+  const { profile, isLoading: profileLoading, reloadProfile } = useUserProfile();
 
   const isLoading = profileLoading || documentsLoading || cardsLoading;
+
+  useFocusEffect(
+    React.useCallback(() => {
+      reloadProfile();
+    }, [])
+  );
 
   // Redirect to profile setup if no profile exists
   useEffect(() => {
@@ -68,22 +74,11 @@ export function WalletHomeScreen() {
         <View className="px-6 pt-4">
           <View className="flex-row items-center justify-between mb-6">
             <View className="flex-row items-center">
-              <View className="w-12 h-12 md:w-14 md:h-14 rounded-full overflow-hidden mr-3">
-                {profile?.photoUri ? (
-                  <Image
-                    source={{ uri: profile.photoUri }}
-                    className="w-full h-full"
-                    resizeMode="cover"
-                  />
-                ) : (
-                  <View className="w-full h-full bg-primary-main/20 items-center justify-center">
-                    <Text className="text-xl md:text-2xl text-text-primary">
-                      👤
-                    </Text>
-                  </View>
-                )}
-              </View>
-              <View>
+              <UserAvatar 
+                photoUri={profile?.photoUri}
+                size={48}
+              />
+              <View className="ml-3">
                 <Text className="text-xs md:text-sm text-text-secondary mb-1">
                   Welcome back,
                 </Text>


### PR DESCRIPTION
## Task
Restaura o layout original da seção Profile em Settings que foi alterado em TASK-3.

## Changes
- Restaurar estrutura de row: avatar | nome+subtitle | chevron
- Manter UserAvatar component
- Manter useFocusEffect para reload de perfil

## Closes
Closes #104

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Photo selection during profile setup: capture a new photo or choose from your gallery
  * Unified avatar component design across all screens

* **Improvements**
  * Profile information automatically refreshes when returning to profile, settings, or wallet screens
  * Enhanced loading indicators for photo operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->