### PR TITLE
fix: restaurar layout de row em Profile de Settings (Task #104)

### DIFF
--- a/src/presentation/screens/settings-screen.tsx
+++ b/src/presentation/screens/settings-screen.tsx
@@ -188,16 +188,24 @@ export function SettingsScreen() {
 
           {/* Profile Section */}
           <SettingsSection title="PROFILE">
-            <View className="items-center py-4 border-b border-gray-200">
+            <Pressable
+              className="flex-row items-center px-4 py-4 border-b border-border-subtle"
+              onPress={() => router.push("/profile-setup")}
+            >
               <UserAvatar
                 photoUri={profile?.photoUri}
-                size={64}
-                onPress={() => router.push("/profile-setup")}
+                size={48}
               />
-              <Text className="mt-3 font-semibold">
-                {profile?.name || "Guest"}
-              </Text>
-            </View>
+              <View className="flex-1 ml-4">
+                <Text className="text-base md:text-lg font-semibold text-text-primary">
+                  {profile?.name || "Guest"}
+                </Text>
+                <Text className="text-sm text-text-secondary mt-1">
+                  Tap to edit profile
+                </Text>
+              </View>
+              <Text className="text-xl text-text-tertiary">›</Text>
+            </Pressable>
           </SettingsSection>
 
           {/* Security Section */}


### PR DESCRIPTION
## Descrição

Restaura o layout de row na seção Profile da tela de Settings conforme solicitado na task #104.

### Alterações:
- **Restaurar estrutura de row**: avatar (esq) + nome+subtitle (centro) + chevron (dir)
- **Manter UserAvatar component** e useFocusEffect de TASK-3
- **Remove onPress redundante** do UserAvatar
- **Restaurar subtitle** 'Tap to edit profile'

### Validações:
- ✅ Apenas 1 arquivo modificado: 
- ✅ useFocusEffect com dependência 
- ✅ Apenas 1 onPress no outer Pressable
- ✅ Estrutura flex-row items-center restaurada

---

@coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profile section in Settings is now fully interactive with clear visual indicators—including a "Tap to edit profile" hint and chevron—guiding users to manage their profile information.

* **Style**
  * Refined avatar sizing and profile row layout for improved visual hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->