### PR TITLE
feat: Persistência de foto no perfil — salvar apenas no botão Save (Task #107)

### DIFF
--- a/src/presentation/hooks/use-profile-photo.ts
+++ b/src/presentation/hooks/use-profile-photo.ts
@@ -84,24 +84,24 @@ export function useProfilePhoto(onPhotoUpdate?: OnPhotoUpdateCallback) {
         "Choose Profile Photo",
         "Select an option to choose your profile photo",
         [
-          { 
-            text: "Cancel", 
+          {
+            text: "Cancel",
             style: "cancel",
-            onPress: () => resolve(null)
+            onPress: () => resolve(null),
           },
-          { 
-            text: "Take Photo", 
+          {
+            text: "Take Photo",
             onPress: async () => {
               const uri = await pickImage("camera");
               resolve(uri);
-            }
+            },
           },
-          { 
-            text: "Choose from Gallery", 
+          {
+            text: "Choose from Gallery",
             onPress: async () => {
               const uri = await pickImage("gallery");
               resolve(uri);
-            }
+            },
           },
         ],
       );

--- a/src/presentation/hooks/use-profile-photo.ts
+++ b/src/presentation/hooks/use-profile-photo.ts
@@ -1,15 +1,11 @@
 import { useState, useCallback } from "react";
 import * as ImagePicker from "expo-image-picker";
 import { Alert } from "react-native";
-import { UpdateProfilePhotoUseCase } from "@domain/use-cases/update-profile-photo.use-case";
-import { UserProfileRepositoryImpl } from "@data/repositories/user-profile.repository.impl";
 
 type OnPhotoUpdateCallback = () => void;
 
 export function useProfilePhoto(onPhotoUpdate?: OnPhotoUpdateCallback) {
   const [isLoading, setIsLoading] = useState(false);
-  const repository = new UserProfileRepositoryImpl();
-  const updatePhotoUseCase = new UpdateProfilePhotoUseCase(repository);
 
   const requestPermissions = useCallback(async () => {
     const { status: cameraStatus } =
@@ -65,17 +61,7 @@ export function useProfilePhoto(onPhotoUpdate?: OnPhotoUpdateCallback) {
 
         if (!result.canceled && result.assets && result.assets.length > 0) {
           const photoUri = result.assets[0].uri;
-
-          const updateResult = await updatePhotoUseCase.execute(photoUri);
-
-          if (updateResult.success) {
-            Alert.alert("Success", updateResult.message, [{ text: "OK" }]);
-            onPhotoUpdate?.();
-            return photoUri;
-          } else {
-            Alert.alert("Error", updateResult.message, [{ text: "OK" }]);
-            return null;
-          }
+          return photoUri; // ← SÓ RETORNA URI, sem persistir
         }
 
         return null;
@@ -89,49 +75,42 @@ export function useProfilePhoto(onPhotoUpdate?: OnPhotoUpdateCallback) {
         setIsLoading(false);
       }
     },
-    [requestPermissions, updatePhotoUseCase, onPhotoUpdate],
+    [requestPermissions],
   );
 
-  const showImagePickerOptions = useCallback(() => {
-    Alert.alert(
-      "Choose Profile Photo",
-      "Select an option to choose your profile photo",
-      [
-        { text: "Cancel", style: "cancel" },
-        { text: "Take Photo", onPress: () => pickImage("camera") },
-        { text: "Choose from Gallery", onPress: () => pickImage("gallery") },
-      ],
-    );
+  const showImagePickerOptions = useCallback(async () => {
+    return new Promise<string | null>((resolve) => {
+      Alert.alert(
+        "Choose Profile Photo",
+        "Select an option to choose your profile photo",
+        [
+          { 
+            text: "Cancel", 
+            style: "cancel",
+            onPress: () => resolve(null)
+          },
+          { 
+            text: "Take Photo", 
+            onPress: async () => {
+              const uri = await pickImage("camera");
+              resolve(uri);
+            }
+          },
+          { 
+            text: "Choose from Gallery", 
+            onPress: async () => {
+              const uri = await pickImage("gallery");
+              resolve(uri);
+            }
+          },
+        ],
+      );
+    });
   }, [pickImage]);
-
-  const removePhoto = useCallback(async () => {
-    setIsLoading(true);
-    try {
-      const result = await updatePhotoUseCase.execute(null);
-
-      if (result.success) {
-        Alert.alert("Success", result.message, [{ text: "OK" }]);
-        onPhotoUpdate?.();
-        return true;
-      } else {
-        Alert.alert("Error", result.message, [{ text: "OK" }]);
-        return false;
-      }
-    } catch (error) {
-      console.error("Error removing photo:", error);
-      Alert.alert("Error", "Failed to remove photo. Please try again.", [
-        { text: "OK" },
-      ]);
-      return false;
-    } finally {
-      setIsLoading(false);
-    }
-  }, [updatePhotoUseCase, onPhotoUpdate]);
 
   return {
     pickImage,
     showImagePickerOptions,
-    removePhoto,
     isLoading,
     requestPermissions,
   };

--- a/src/presentation/screens/profile-setup-screen.tsx
+++ b/src/presentation/screens/profile-setup-screen.tsx
@@ -17,8 +17,8 @@ export function ProfileSetupScreen() {
   const router = useRouter();
   const [photoUri, setPhotoUri] = useState<string | null>(null);
   const { profile, saveProfile, reloadProfile } = useUserProfile();
-  const { pickImage, isLoading: isPhotoLoading } =
-    useProfilePhoto(reloadProfile);
+  const { pickImage, showImagePickerOptions, isLoading: isPhotoLoading } =
+    useProfilePhoto();
   const [name, setName] = useState("");
   const [isSaving, setIsSaving] = useState(false);
 
@@ -50,7 +50,10 @@ export function ProfileSetupScreen() {
     }
 
     setIsSaving(true);
-    const result = await saveProfile({ name: name.trim() });
+    const result = await saveProfile({ 
+      name: name.trim(),
+      photoUri: photoUri ?? undefined, // ← Incluir photoUri
+    });
     setIsSaving(false);
 
     if (result.success) {
@@ -66,31 +69,10 @@ export function ProfileSetupScreen() {
   };
 
   const handleSelectPhoto = async () => {
-    Alert.alert(
-      "Choose Profile Photo",
-      "Select an option to choose your profile photo",
-      [
-        { text: "Cancel", style: "cancel" },
-        {
-          text: "Take Photo",
-          onPress: async () => {
-            const newPhotoUri = await pickImage("camera");
-            if (newPhotoUri) {
-              setPhotoUri(newPhotoUri);
-            }
-          },
-        },
-        {
-          text: "Choose from Gallery",
-          onPress: async () => {
-            const newPhotoUri = await pickImage("gallery");
-            if (newPhotoUri) {
-              setPhotoUri(newPhotoUri);
-            }
-          },
-        },
-      ],
-    );
+    const newUri = await showImagePickerOptions();
+    if (newUri) {
+      setPhotoUri(newUri); // ← Apenas atualiza estado local
+    }
   };
 
   return (

--- a/src/presentation/screens/profile-setup-screen.tsx
+++ b/src/presentation/screens/profile-setup-screen.tsx
@@ -17,8 +17,11 @@ export function ProfileSetupScreen() {
   const router = useRouter();
   const [photoUri, setPhotoUri] = useState<string | null>(null);
   const { profile, saveProfile, reloadProfile } = useUserProfile();
-  const { pickImage, showImagePickerOptions, isLoading: isPhotoLoading } =
-    useProfilePhoto();
+  const {
+    pickImage,
+    showImagePickerOptions,
+    isLoading: isPhotoLoading,
+  } = useProfilePhoto();
   const [name, setName] = useState("");
   const [isSaving, setIsSaving] = useState(false);
 
@@ -50,7 +53,7 @@ export function ProfileSetupScreen() {
     }
 
     setIsSaving(true);
-    const result = await saveProfile({ 
+    const result = await saveProfile({
       name: name.trim(),
       photoUri: photoUri ?? undefined, // ← Incluir photoUri
     });

--- a/src/presentation/screens/settings-screen.tsx
+++ b/src/presentation/screens/settings-screen.tsx
@@ -192,10 +192,7 @@ export function SettingsScreen() {
               className="flex-row items-center px-4 py-4 border-b border-border-subtle"
               onPress={() => router.push("/profile-setup")}
             >
-              <UserAvatar
-                photoUri={profile?.photoUri}
-                size={48}
-              />
+              <UserAvatar photoUri={profile?.photoUri} size={48} />
               <View className="flex-1 ml-4">
                 <Text className="text-base md:text-lg font-semibold text-text-primary">
                   {profile?.name || "Guest"}


### PR DESCRIPTION
## Task
Remove immediate photo persistence from useProfilePhoto hook and implements local state management in profile-setup-screen.

## Changes
- useProfilePhoto: remove UpdateProfilePhotoUseCase call from pickImage
- profile-setup-screen: add local photoUri state, save only on Save button

## Closes
Closes #107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined profile photo selection workflow during account setup
  * Removed photo deletion capability from profile management
  * Profile photos now persist when you save your profile settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->