### PR TITLE
fix: add issues write permission to close-issues workflow

### DIFF
--- a/.github/workflows/close-issues-on-merge.yml
+++ b/.github/workflows/close-issues-on-merge.yml
@@ -9,6 +9,8 @@ jobs:
     name: Close linked issues
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true
+    permissions:
+      issues: write
 
     steps:
       - name: Close issues referenced in PR body


### PR DESCRIPTION
The workflow was failing to close issues because GITHUB_TOKEN lacked the 'issues: write' permission. This fix allows the workflow to properly close linked issues when PRs are merged.