### PR TITLE
feat: TASK-4: Remove 'Iniciar Auto-lock' container from WalletHomeScreen

### DIFF
--- a/src/presentation/screens/wallet-home-screen-autolock-button.integration.test.ts
+++ b/src/presentation/screens/wallet-home-screen-autolock-button.integration.test.ts
@@ -1,13 +1,13 @@
 /**
- * Integration test for WalletHomeScreen auto-lock button
- * Validates implementation of auto-lock button on home screen
- * Tests code presence, structure, and correct implementation of TASK-13
+ * Integration test for WalletHomeScreen auto-lock button removal
+ * Validates that auto-lock button has been removed from home screen
+ * Tests that TASK-4 (remove auto-lock container) is properly implemented
  */
 
 import { readFileSync } from "fs";
 import { join } from "path";
 
-describe("WalletHomeScreen - Auto-lock Button Integration Tests", () => {
+describe("WalletHomeScreen - Auto-lock Button Removal Integration Tests", () => {
   const componentPath = join(__dirname, "./wallet-home-screen.tsx");
   let componentCode: string;
 
@@ -15,85 +15,51 @@ describe("WalletHomeScreen - Auto-lock Button Integration Tests", () => {
     componentCode = readFileSync(componentPath, "utf8");
   });
 
-  describe("Auto-lock Button Implementation", () => {
-    it("should import necessary dependencies", () => {
-      expect(componentCode).toContain(
-        'import { useRouter, useFocusEffect } from "expo-router"',
-      );
-      expect(componentCode).toContain(
-        'import { useDocuments } from "@presentation/hooks/use-documents"',
-      );
-    });
-
-    it("should check for documents with isAutoLockEnabled: true using .some()", () => {
-      expect(componentCode).toContain(
+  describe("Auto-lock Button Removal Validation", () => {
+    it("should NOT contain auto-lock button conditional rendering", () => {
+      expect(componentCode).not.toContain(
         "documents.some((doc) => doc.isAutoLockEnabled)",
       );
     });
 
-    it("should conditionally render auto-lock button container", () => {
-      expect(componentCode).toContain(
-        "{documents && documents.some((doc) => doc.isAutoLockEnabled) && (",
-      );
-    });
-
-    it("should have proper View structure for button container", () => {
-      expect(componentCode).toContain(
+    it("should NOT contain auto-lock button container", () => {
+      expect(componentCode).not.toContain(
         'className="border-2 border-warning-main rounded-2xl p-5 md:p-6 mb-6"',
       );
     });
 
-    it("should display auto-lock icon emoji", () => {
-      expect(componentCode).toContain("🔒");
+    it("should NOT display auto-lock icon emoji", () => {
+      expect(componentCode).not.toContain("🔒");
     });
 
-    it("should display main button title in Portuguese", () => {
-      expect(componentCode).toContain("Iniciar Auto-lock");
+    it("should NOT display main button title in Portuguese", () => {
+      expect(componentCode).not.toContain("Iniciar Auto-lock");
     });
 
-    it("should display button subtitle text", () => {
-      expect(componentCode).toContain("Compartilhar documentos selecionados");
+    it("should NOT display button subtitle text", () => {
+      expect(componentCode).not.toContain("Compartilhar documentos selecionados");
     });
 
-    it("should display action button text in Portuguese", () => {
-      expect(componentCode).toContain("Iniciar Modo Convidado");
+    it("should NOT display action button text in Portuguese", () => {
+      expect(componentCode).not.toContain("Iniciar Modo Convidado");
     });
 
-    it("should use correct warning color styling", () => {
-      expect(componentCode).toContain("bg-warning-main/20");
-      expect(componentCode).toContain("border-warning-main");
-      expect(componentCode).toContain("bg-warning-main");
-    });
-
-    it("should have proper button styling with active state", () => {
-      expect(componentCode).toContain(
+    it("should NOT have auto-lock button styling", () => {
+      expect(componentCode).not.toContain(
         'className="bg-warning-main rounded-xl py-3.5 items-center active:opacity-90"',
       );
     });
   });
 
   describe("Navigation Implementation", () => {
-    it("should use router.replace() for guest-mode navigation", () => {
-      expect(componentCode).toContain('router.replace("/guest-mode")');
-    });
-
-    it("should not use router.push() for guest-mode navigation", () => {
-      // router.replace is preferred over router.push for guest-mode
-      const hasReplace = componentCode.includes(
-        'router.replace("/guest-mode")',
+    it("should NOT use router.replace() for guest-mode navigation in auto-lock context", () => {
+      // The component should not have router.replace("/guest-mode") for auto-lock button
+      // It might still exist elsewhere in the codebase, but not for auto-lock
+      const lines = componentCode.split("\n");
+      const guestModeLines = lines.filter((line) => 
+        line.includes('router.replace("/guest-mode")')
       );
-      const lineWithGuestMode = componentCode
-        .split("\n")
-        .find((line) => line.includes("guest-mode"));
-
-      expect(hasReplace).toBe(true);
-      expect(lineWithGuestMode).toContain("router.replace");
-    });
-
-    it("should attach navigation handler to Pressable component", () => {
-      expect(componentCode).toContain(
-        'onPress={() => router.replace("/guest-mode")}',
-      );
+      expect(guestModeLines.length).toBe(0);
     });
   });
 
@@ -118,19 +84,6 @@ describe("WalletHomeScreen - Auto-lock Button Integration Tests", () => {
     it("should reload profile on focus effect", () => {
       expect(componentCode).toContain("reloadProfile();");
     });
-
-    it("should have correct dependencies array in useCallback", () => {
-      expect(componentCode).toContain("[reloadProfile, loadDocuments]");
-    });
-
-    it("should have both reloadProfile and loadDocuments as dependencies", () => {
-      const focusEffectSection = componentCode.substring(
-        componentCode.indexOf("useFocusEffect"),
-        componentCode.indexOf("useFocusEffect") + 800,
-      );
-      expect(focusEffectSection).toContain("reloadProfile");
-      expect(focusEffectSection).toContain("loadDocuments");
-    });
   });
 
   describe("Hook Integration", () => {
@@ -138,127 +91,40 @@ describe("WalletHomeScreen - Auto-lock Button Integration Tests", () => {
       expect(componentCode).toContain("reload: loadDocuments");
     });
 
-    it("should use documents from useDocuments hook in conditional rendering", () => {
-      expect(componentCode).toContain(
-        "documents.some((doc) => doc.isAutoLockEnabled)",
-      );
-    });
-
     it("should have useRouter hook imported and used", () => {
       expect(componentCode).toContain("const router = useRouter()");
     });
   });
 
-  describe("UI Layout Structure", () => {
-    it("should have proper flex-row layout for icon and text", () => {
-      expect(componentCode).toContain('className="flex-row items-center mb-3"');
-    });
-
-    it("should have icon container with proper dimensions", () => {
-      expect(componentCode).toContain("w-10 h-10");
-      expect(componentCode).toContain("rounded-full");
-    });
-
-    it("should properly align icon and text content", () => {
-      expect(componentCode).toContain("items-center");
-      expect(componentCode).toContain("justify-center");
-    });
-
-    it("should have responsive text sizing", () => {
-      expect(componentCode).toContain("text-lg md:text-xl");
-      expect(componentCode).toContain("text-sm md:text-base");
-      expect(componentCode).toContain("text-base md:text-lg");
-    });
-
-    it("should use consistent spacing throughout button", () => {
-      expect(componentCode).toContain("mb-");
-      expect(componentCode).toContain("p-5 md:p-6");
-      expect(componentCode).toContain("py-3.5");
-    });
-  });
-
-  describe("Conditional Rendering Logic", () => {
-    it("should only render button when documents exist with isAutoLockEnabled", () => {
-      const lines = componentCode.split("\n");
-      const autoLockSection = lines.filter((line) =>
-        line.includes("documents.some((doc) => doc.isAutoLockEnabled)"),
-      );
-      expect(autoLockSection.length).toBeGreaterThan(0);
-    });
-
-    it("should place auto-lock button in correct position in component", () => {
-      const indexOfAutoLock = componentCode.indexOf(
-        "documents.some(doc => doc.isAutoLockEnabled)",
-      );
-      const indexOfDocuments = componentCode.indexOf("MY DOCUMENTS");
-
-      // Auto-lock button should come before documents section
-      expect(indexOfAutoLock).toBeLessThan(indexOfDocuments);
-    });
-
-    it("should render button before documents list", () => {
-      const autoLockIndex = componentCode.indexOf("Iniciar Auto-lock");
-      const documentsHeaderIndex = componentCode.indexOf("MY DOCUMENTS");
-
-      expect(autoLockIndex).toBeGreaterThan(-1);
-      expect(documentsHeaderIndex).toBeGreaterThan(-1);
-      expect(autoLockIndex).toBeLessThan(documentsHeaderIndex);
-    });
-  });
-
-  describe("Documentation and Comments", () => {
-    it("should have comment marking auto-lock button section", () => {
-      expect(componentCode).toContain("{/* Auto-lock Button */}");
-    });
-  });
-
-  describe("Complete Feature Validation (TASK-13 Definition of DONE)", () => {
-    it("✓ Botão implementado na WalletHomeScreen", () => {
-      expect(componentCode).toContain("Iniciar Auto-lock");
-      expect(componentCode).toContain("WalletHomeScreen");
-    });
-
-    it("✓ Lógica condicional funcionando (aparece/desaparece com documentos)", () => {
+  describe("Secure Sharing Button Validation", () => {
+    it("should have secure sharing button with correct styling", () => {
       expect(componentCode).toContain(
-        "documents && documents.some((doc) => doc.isAutoLockEnabled) && (",
+        'className="bg-white rounded-xl py-3.5 items-center active:opacity-90"',
       );
     });
 
-    it("✓ Navegação com router.replace() funcionando", () => {
-      expect(componentCode).toContain('router.replace("/guest-mode")');
+    it("should have secure sharing button text", () => {
+      expect(componentCode).toContain("Start Sharing");
     });
 
-    it("✓ useFocusEffect implementado para refresh dinâmico", () => {
-      expect(componentCode).toContain("useFocusEffect");
-      expect(componentCode).toContain("loadDocuments");
-      expect(componentCode).toContain("reloadProfile");
-    });
-
-    it("✓ Teste cobrindo renderização condicional", () => {
-      // This verifies the integration test itself validates the behavior
-      expect(componentCode).toContain("isAutoLockEnabled");
+    it("should navigate to select-documents from secure sharing button", () => {
+      expect(componentCode).toContain('router.push("/select-documents")');
     });
   });
 
-  describe("Code Quality Checks", () => {
-    it("should not have unused imports", () => {
-      // If imports exist, they should be used
-      if (componentCode.includes("import React")) {
-        expect(componentCode).toContain("React.useCallback");
-      }
+  describe("Complete Feature Validation (TASK-4 Definition of DONE)", () => {
+    it("✓ Auto-lock button removed from WalletHomeScreen", () => {
+      expect(componentCode).not.toContain("Iniciar Auto-lock");
     });
 
-    it("should have proper className formatting", () => {
-      expect(componentCode).not.toContain('className=""');
+    it("✓ Secure sharing flow remains accessible via 'Start Sharing' button", () => {
+      expect(componentCode).toContain("Start Sharing");
+      expect(componentCode).toContain('router.push("/select-documents")');
     });
 
-    it("should use consistent quotes", () => {
-      // Check predominant quote style
-      const doubleQuotes = (componentCode.match(/"/g) || []).length;
-      const singleQuotes = (componentCode.match(/'/g) || []).length;
-
-      // Both are acceptable in TypeScript/React, just checking for consistency
-      expect(doubleQuotes + singleQuotes).toBeGreaterThan(0);
+    it("✓ No redundant entry points for guest mode", () => {
+      const guestModeCount = (componentCode.match(/guest-mode/g) || []).length;
+      expect(guestModeCount).toBe(0);
     });
   });
 });

--- a/src/presentation/screens/wallet-home-screen.test.tsx
+++ b/src/presentation/screens/wallet-home-screen.test.tsx
@@ -1,10 +1,10 @@
 /**
- * Unit tests for WalletHomeScreen - Auto-lock Button Feature (TASK-13)
- * Tests button rendering, visibility conditions, navigation, and focus effect
+ * Unit tests for WalletHomeScreen (post TASK-4)
+ * Auto-lock button has been removed. Tests reflect current component state.
  */
 
 import React from "react";
-import { render, fireEvent, waitFor } from "@testing-library/react-native";
+import { render, fireEvent } from "@testing-library/react-native";
 import { useRouter, useFocusEffect } from "expo-router";
 import { useDocuments } from "@presentation/hooks/use-documents";
 import { useCreditCards } from "@presentation/hooks/use-credit-cards";
@@ -81,13 +81,12 @@ const mockProfile = {
   photoUri: "https://example.com/photo.jpg",
 };
 
-describe("WalletHomeScreen - Auto-lock Button Tests", () => {
+describe("WalletHomeScreen", () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
     (useRouter as jest.Mock).mockReturnValue(mockRouter);
     (useFocusEffect as jest.Mock).mockImplementation((cb) => {
-      // Call the callback immediately for testing
       cb();
     });
 
@@ -109,22 +108,32 @@ describe("WalletHomeScreen - Auto-lock Button Tests", () => {
     });
   });
 
-  describe("Auto-lock Button Visibility", () => {
-    it("should render auto-lock button when at least one document has isAutoLockEnabled: true", () => {
-      const { getByText } = render(<WalletHomeScreen />);
-      expect(getByText("Iniciar Auto-lock")).toBeTruthy();
+  describe("Auto-lock Button Removal (TASK-4)", () => {
+    it("should NOT render auto-lock button regardless of isAutoLockEnabled", () => {
+      const { queryByText } = render(<WalletHomeScreen />);
+      expect(queryByText("Iniciar Auto-lock")).toBeNull();
     });
 
-    it("should not render auto-lock button when no documents have isAutoLockEnabled: true", () => {
+    it("should NOT render auto-lock subtitle text", () => {
+      const { queryByText } = render(<WalletHomeScreen />);
+      expect(queryByText("Compartilhar documentos selecionados")).toBeNull();
+    });
+
+    it("should NOT render guest mode button from auto-lock flow", () => {
+      const { queryByText } = render(<WalletHomeScreen />);
+      expect(queryByText("Iniciar Modo Convidado")).toBeNull();
+    });
+
+    it("should NOT render auto-lock lock icon emoji", () => {
+      const { queryByText } = render(<WalletHomeScreen />);
+      expect(queryByText("🔒")).toBeNull();
+    });
+
+    it("should NOT render auto-lock button even when all documents have isAutoLockEnabled: true", () => {
       (useDocuments as jest.Mock).mockReturnValue({
         documents: [
-          {
-            id: "1",
-            type: "CNH",
-            fullName: "John Doe",
-            documentNumber: "12345678901",
-            isAutoLockEnabled: false,
-          },
+          { id: "1", type: "CNH", fullName: "John Doe", documentNumber: "12345678901", isAutoLockEnabled: true },
+          { id: "2", type: "RG", fullName: "John Doe", documentNumber: "98765432100", isAutoLockEnabled: true },
         ],
         isLoading: false,
         reload: jest.fn(),
@@ -133,58 +142,105 @@ describe("WalletHomeScreen - Auto-lock Button Tests", () => {
       const { queryByText } = render(<WalletHomeScreen />);
       expect(queryByText("Iniciar Auto-lock")).toBeNull();
     });
+  });
 
-    it("should not render auto-lock button when documents array is empty", () => {
+  describe("Secure Sharing Mode Section", () => {
+    it("should render Secure Sharing Mode title", () => {
+      const { getByText } = render(<WalletHomeScreen />);
+      expect(getByText("Secure Sharing Mode")).toBeTruthy();
+    });
+
+    it("should render Start Sharing button", () => {
+      const { getByText } = render(<WalletHomeScreen />);
+      expect(getByText("Start Sharing")).toBeTruthy();
+    });
+
+    it("should navigate to /select-documents when Start Sharing is pressed", () => {
+      const { getByText } = render(<WalletHomeScreen />);
+      fireEvent.press(getByText("Start Sharing"));
+      expect(mockRouter.push).toHaveBeenCalledWith("/select-documents");
+    });
+
+    it("should NOT navigate to /guest-mode from Secure Sharing button", () => {
+      const { getByText } = render(<WalletHomeScreen />);
+      fireEvent.press(getByText("Start Sharing"));
+      expect(mockRouter.replace).not.toHaveBeenCalledWith("/guest-mode");
+      expect(mockRouter.push).not.toHaveBeenCalledWith("/guest-mode");
+    });
+  });
+
+  describe("Quick Actions Section", () => {
+    it("should render QUICK ACTIONS section header", () => {
+      const { getByText } = render(<WalletHomeScreen />);
+      expect(getByText("QUICK ACTIONS")).toBeTruthy();
+    });
+  });
+
+  describe("Profile Display", () => {
+    it("should render welcome back text", () => {
+      const { getByText } = render(<WalletHomeScreen />);
+      expect(getByText("Welcome back,")).toBeTruthy();
+    });
+
+    it("should render user name from profile", () => {
+      const { getAllByText } = render(<WalletHomeScreen />);
+      // "John Doe" appears in profile header and also in document list fullName
+      expect(getAllByText("John Doe").length).toBeGreaterThan(0);
+    });
+
+    it("should handle null profile without crashing", () => {
+      (useUserProfile as jest.Mock).mockReturnValue({
+        profile: null,
+        isLoading: false,
+        reloadProfile: jest.fn(),
+      });
+
+      expect(() => render(<WalletHomeScreen />)).not.toThrow();
+    });
+  });
+
+  describe("Documents Section", () => {
+    it("should render MY DOCUMENTS section header", () => {
+      const { getByText } = render(<WalletHomeScreen />);
+      expect(getByText("MY DOCUMENTS")).toBeTruthy();
+    });
+
+    it("should render See All link", () => {
+      const { getByText } = render(<WalletHomeScreen />);
+      expect(getByText("See All")).toBeTruthy();
+    });
+
+    it("should render documents list", () => {
+      const { getByText } = render(<WalletHomeScreen />);
+      expect(getByText("Driver's License")).toBeTruthy();
+    });
+
+    it("should show empty state when no documents", () => {
       (useDocuments as jest.Mock).mockReturnValue({
         documents: [],
         isLoading: false,
         reload: jest.fn(),
       });
 
-      const { queryByText } = render(<WalletHomeScreen />);
-      expect(queryByText("Iniciar Auto-lock")).toBeNull();
+      const { getByText } = render(<WalletHomeScreen />);
+      expect(getByText("No documents yet. Add your first document!")).toBeTruthy();
     });
 
-    it("should render auto-lock button with correct subtitle text", () => {
-      const { getByText } = render(<WalletHomeScreen />);
-      expect(getByText("Compartilhar documentos selecionados")).toBeTruthy();
+    it("should handle undefined documents gracefully", () => {
+      (useDocuments as jest.Mock).mockReturnValue({
+        documents: undefined,
+        isLoading: false,
+        reload: jest.fn(),
+      });
+
+      expect(() => render(<WalletHomeScreen />)).not.toThrow();
     });
   });
 
-  describe("Auto-lock Button Navigation", () => {
-    it("should navigate to /guest-mode when auto-lock button is pressed", () => {
-      const { getByText } = render(<WalletHomeScreen />);
-      const guestModeButton = getByText("Iniciar Modo Convidado");
-
-      fireEvent.press(guestModeButton);
-
-      expect(mockRouter.replace).toHaveBeenCalledWith("/guest-mode");
-    });
-
-    it("should use router.replace instead of router.push for guest-mode navigation", () => {
-      const { getByText } = render(<WalletHomeScreen />);
-      const guestModeButton = getByText("Iniciar Modo Convidado");
-
-      fireEvent.press(guestModeButton);
-
-      expect(mockRouter.replace).toHaveBeenCalledWith("/guest-mode");
-      expect(mockRouter.push).not.toHaveBeenCalled();
-    });
-
-    it("should trigger button press only once per interaction", () => {
-      const { getByText } = render(<WalletHomeScreen />);
-      const guestModeButton = getByText("Iniciar Modo Convidado");
-
-      fireEvent.press(guestModeButton);
-
-      expect(mockRouter.replace).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe("Focus Effect and Document Reload", () => {
-    it("should call useFocusEffect with callback", () => {
+  describe("Focus Effect and Data Reload", () => {
+    it("should call useFocusEffect with a callback", () => {
       render(<WalletHomeScreen />);
-      expect(useFocusEffect).toHaveBeenCalled();
+      expect(useFocusEffect).toHaveBeenCalledWith(expect.any(Function));
     });
 
     it("should reload documents on screen focus", () => {
@@ -196,11 +252,10 @@ describe("WalletHomeScreen - Auto-lock Button Tests", () => {
       });
 
       (useFocusEffect as jest.Mock).mockImplementation((cb) => {
-        cb(); // Execute the callback immediately (simulating focus)
+        cb();
       });
 
       render(<WalletHomeScreen />);
-
       expect(mockLoadDocuments).toHaveBeenCalled();
     });
 
@@ -213,11 +268,10 @@ describe("WalletHomeScreen - Auto-lock Button Tests", () => {
       });
 
       (useFocusEffect as jest.Mock).mockImplementation((cb) => {
-        cb(); // Execute the callback immediately (simulating focus)
+        cb();
       });
 
       render(<WalletHomeScreen />);
-
       expect(mockReloadProfile).toHaveBeenCalled();
     });
 
@@ -238,151 +292,17 @@ describe("WalletHomeScreen - Auto-lock Button Tests", () => {
       });
 
       (useFocusEffect as jest.Mock).mockImplementation((cb) => {
-        cb(); // Execute the callback immediately (simulating focus)
+        cb();
       });
 
       render(<WalletHomeScreen />);
-
       expect(mockReloadProfile).toHaveBeenCalled();
       expect(mockLoadDocuments).toHaveBeenCalled();
     });
-
-    it("should include loadDocuments in focus effect dependencies", () => {
-      const mockLoadDocuments = jest.fn();
-      (useDocuments as jest.Mock).mockReturnValue({
-        documents: mockDocuments,
-        isLoading: false,
-        reload: mockLoadDocuments,
-      });
-
-      render(<WalletHomeScreen />);
-
-      // useFocusEffect should receive a callback function
-      expect(useFocusEffect).toHaveBeenCalledWith(expect.any(Function));
-    });
   });
 
-  describe("Button Styling and UI Elements", () => {
-    it("should have correct icon emoji for auto-lock button", () => {
-      const { getByText } = render(<WalletHomeScreen />);
-      expect(getByText("🔒")).toBeTruthy();
-    });
-
-    it("should display proper button labels in Portuguese", () => {
-      const { getByText } = render(<WalletHomeScreen />);
-      expect(getByText("Iniciar Auto-lock")).toBeTruthy();
-      expect(getByText("Compartilhar documentos selecionados")).toBeTruthy();
-      expect(getByText("Iniciar Modo Convidado")).toBeTruthy();
-    });
-  });
-
-  describe("Multiple Documents Scenarios", () => {
-    it("should render button when first document has isAutoLockEnabled: true", () => {
-      const { getByText } = render(<WalletHomeScreen />);
-      expect(getByText("Iniciar Auto-lock")).toBeTruthy();
-    });
-
-    it("should render button when any document in list has isAutoLockEnabled: true", () => {
-      (useDocuments as jest.Mock).mockReturnValue({
-        documents: [
-          {
-            id: "1",
-            type: "CNH",
-            fullName: "John Doe",
-            documentNumber: "12345678901",
-            isAutoLockEnabled: false,
-          },
-          {
-            id: "2",
-            type: "RG",
-            fullName: "John Doe",
-            documentNumber: "98765432100",
-            isAutoLockEnabled: true,
-          },
-          {
-            id: "3",
-            type: "CNH",
-            fullName: "John Doe",
-            documentNumber: "11111111111",
-            isAutoLockEnabled: false,
-          },
-        ],
-        isLoading: false,
-        reload: jest.fn(),
-      });
-
-      const { getByText } = render(<WalletHomeScreen />);
-      expect(getByText("Iniciar Auto-lock")).toBeTruthy();
-    });
-
-    it("should not render button when all documents have isAutoLockEnabled: false", () => {
-      (useDocuments as jest.Mock).mockReturnValue({
-        documents: [
-          {
-            id: "1",
-            type: "CNH",
-            fullName: "John Doe",
-            documentNumber: "12345678901",
-            isAutoLockEnabled: false,
-          },
-          {
-            id: "2",
-            type: "RG",
-            fullName: "John Doe",
-            documentNumber: "98765432100",
-            isAutoLockEnabled: false,
-          },
-        ],
-        isLoading: false,
-        reload: jest.fn(),
-      });
-
-      const { queryByText } = render(<WalletHomeScreen />);
-      expect(queryByText("Iniciar Auto-lock")).toBeNull();
-    });
-  });
-
-  describe("Edge Cases", () => {
-    it("should handle undefined documents gracefully", () => {
-      (useDocuments as jest.Mock).mockReturnValue({
-        documents: undefined,
-        isLoading: false,
-        reload: jest.fn(),
-      });
-
-      // Should not crash
-      expect(() => {
-        render(<WalletHomeScreen />);
-      }).not.toThrow();
-    });
-
-    it("should handle null profile without crashing", () => {
-      (useUserProfile as jest.Mock).mockReturnValue({
-        profile: null,
-        isLoading: false,
-        reloadProfile: jest.fn(),
-      });
-
-      // Should not crash and should navigate to profile-setup
-      expect(() => {
-        render(<WalletHomeScreen />);
-      }).not.toThrow();
-    });
-
-    it("should handle loading state for documents", () => {
-      (useDocuments as jest.Mock).mockReturnValue({
-        documents: [],
-        isLoading: true,
-        reload: jest.fn(),
-      });
-
-      const { queryByText } = render(<WalletHomeScreen />);
-      expect(queryByText("Iniciar Auto-lock")).toBeNull();
-    });
-  });
-
-  describe("Integration: Auto-lock Feature Complete Flow", () => {
-    it("should show button, handle focus effect, and navigate correctly", () => {
+  describe("Integration: Complete Screen Flow", () => {
+    it("should render screen without auto-lock, show secure sharing, and handle focus effect", () => {
       const mockLoadDocuments = jest.fn();
       const mockReloadProfile = jest.fn();
 
@@ -399,22 +319,26 @@ describe("WalletHomeScreen - Auto-lock Button Tests", () => {
       });
 
       (useFocusEffect as jest.Mock).mockImplementation((cb) => {
-        cb(); // Execute the callback immediately (simulating focus)
+        cb();
       });
 
-      const { getByText } = render(<WalletHomeScreen />);
+      const { getByText, queryByText } = render(<WalletHomeScreen />);
 
-      // 1. Button should be visible
-      expect(getByText("Iniciar Auto-lock")).toBeTruthy();
+      // 1. Auto-lock button should NOT be present
+      expect(queryByText("Iniciar Auto-lock")).toBeNull();
+      expect(queryByText("Iniciar Modo Convidado")).toBeNull();
 
-      // 2. Focus effect should reload both profile and documents
+      // 2. Secure Sharing section should be present
+      expect(getByText("Secure Sharing Mode")).toBeTruthy();
+      expect(getByText("Start Sharing")).toBeTruthy();
+
+      // 3. Focus effect should reload both profile and documents
       expect(mockReloadProfile).toHaveBeenCalled();
       expect(mockLoadDocuments).toHaveBeenCalled();
 
-      // 3. Button press should navigate to guest-mode
-      const guestModeButton = getByText("Iniciar Modo Convidado");
-      fireEvent.press(guestModeButton);
-      expect(mockRouter.replace).toHaveBeenCalledWith("/guest-mode");
+      // 4. Start Sharing navigates to /select-documents
+      fireEvent.press(getByText("Start Sharing"));
+      expect(mockRouter.push).toHaveBeenCalledWith("/select-documents");
     });
   });
 });

--- a/src/presentation/screens/wallet-home-screen.tsx
+++ b/src/presentation/screens/wallet-home-screen.tsx
@@ -149,8 +149,6 @@ export function WalletHomeScreen() {
             </Pressable>
           </View>
 
-
-
           <View className="mb-6">
             <View className="flex-row items-center justify-between mb-4">
               <Text className="text-xs md:text-sm font-semibold text-text-secondary tracking-wider">

--- a/src/presentation/screens/wallet-home-screen.tsx
+++ b/src/presentation/screens/wallet-home-screen.tsx
@@ -149,32 +149,7 @@ export function WalletHomeScreen() {
             </Pressable>
           </View>
 
-          {/* Auto-lock Button */}
-          {documents && documents.some((doc) => doc.isAutoLockEnabled) && (
-            <View className="border-2 border-warning-main rounded-2xl p-5 md:p-6 mb-6">
-              <View className="flex-row items-center mb-3">
-                <View className="w-10 h-10 bg-warning-main/20 rounded-full items-center justify-center mr-3">
-                  <Text className="text-xl">🔒</Text>
-                </View>
-                <View className="flex-1">
-                  <Text className="text-lg md:text-xl font-bold text-text-primary">
-                    Iniciar Auto-lock
-                  </Text>
-                  <Text className="text-sm md:text-base text-text-secondary mt-1">
-                    Compartilhar documentos selecionados
-                  </Text>
-                </View>
-              </View>
-              <Pressable
-                className="bg-warning-main rounded-xl py-3.5 items-center active:opacity-90"
-                onPress={() => router.replace("/guest-mode")}
-              >
-                <Text className="text-base md:text-lg font-bold text-white">
-                  Iniciar Modo Convidado
-                </Text>
-              </Pressable>
-            </View>
-          )}
+
 
           <View className="mb-6">
             <View className="flex-row items-center justify-between mb-4">


### PR DESCRIPTION
Removes redundant Auto-lock entry point. Fixes #148