### PR TITLE
feat: TASK-6 — GuestModeScreen improvements (PIN auth & docIds filtering)

### DIFF
--- a/src/presentation/components/pin-auth-bottom-sheet.tsx
+++ b/src/presentation/components/pin-auth-bottom-sheet.tsx
@@ -1,0 +1,165 @@
+import { View, Text, Pressable, Modal } from "react-native";
+import { useState, useEffect } from "react";
+import { PinDot } from "./pin-dot";
+import { NumericKeypad } from "./numeric-keypad";
+import { PinRepositoryImpl } from "@data/repositories/pin.repository.impl";
+import { VerifyPinUseCase } from "@domain/use-cases/verify-pin.use-case";
+
+interface PinAuthBottomSheetProps {
+  visible: boolean;
+  onSuccess: () => void;
+  onClose: () => void;
+  title?: string;
+  subtitle?: string;
+}
+
+const PIN_LENGTH = 6;
+
+export function PinAuthBottomSheet({
+  visible,
+  onSuccess,
+  onClose,
+  title = "Enter PIN to Exit",
+  subtitle = "Please enter your 6-digit PIN to exit Secure Mode.",
+}: PinAuthBottomSheetProps) {
+  const [pin, setPin] = useState("");
+  const [error, setError] = useState("");
+  const [isVerifying, setIsVerifying] = useState(false);
+
+  const handleKeyPress = (value: string) => {
+    if (pin.length < PIN_LENGTH) {
+      setPin(pin + value);
+      setError("");
+    }
+  };
+
+  const handleBackspace = () => {
+    setPin(pin.slice(0, -1));
+    setError("");
+  };
+
+  const verifyPin = async () => {
+    if (pin.length !== PIN_LENGTH) {
+      setError("PIN must be 6 digits");
+      return;
+    }
+
+    setIsVerifying(true);
+    try {
+      const repository = new PinRepositoryImpl();
+      const verifyPinUseCase = new VerifyPinUseCase(repository);
+      const result = await verifyPinUseCase.execute(pin);
+
+      if (result.success) {
+        setPin("");
+        setError("");
+        onSuccess();
+      } else {
+        setError(result.message || "Invalid PIN. Please try again.");
+        setTimeout(() => {
+          setPin("");
+          setError("");
+        }, 1500);
+      }
+    } catch (err) {
+      setError("Failed to verify PIN. Please try again.");
+      setTimeout(() => {
+        setPin("");
+        setError("");
+      }, 1500);
+    } finally {
+      setIsVerifying(false);
+    }
+  };
+
+  useEffect(() => {
+    if (pin.length === PIN_LENGTH && !isVerifying) {
+      verifyPin();
+    }
+  }, [pin]);
+
+  const handleClose = () => {
+    setPin("");
+    setError("");
+    onClose();
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={handleClose}
+    >
+      <Pressable
+        className="flex-1 bg-black/70 justify-end"
+        onPress={handleClose}
+      >
+        <Pressable
+          className="bg-background-primary rounded-t-3xl h-[80%]"
+          onPress={(e) => e.stopPropagation()}
+        >
+          <View className="flex-1 w-full max-w-[500px] self-center">
+            <View className="items-center pt-4 pb-2">
+              <View className="w-12 h-1 bg-ui-border rounded-full mb-4" />
+              <Text className="text-base text-text-secondary">
+                Secure Mode
+              </Text>
+            </View>
+
+            <View className="px-4 md:px-8 pt-4">
+              <View className="items-center">
+                <Text className="text-3xl md:text-4xl font-bold text-text-primary mb-2">
+                  {title}
+                </Text>
+                <Text className="text-sm md:text-base text-text-secondary text-center px-6 md:px-8">
+                  {subtitle}
+                </Text>
+              </View>
+
+              {error && (
+                <View className="items-center mt-4 mb-2">
+                  <Text className="text-sm font-semibold text-status-error text-center px-4">
+                    {error}
+                  </Text>
+                </View>
+              )}
+
+              <View className="items-center mt-6">
+                <View className="flex-row gap-3 md:gap-5">
+                  {Array.from({ length: PIN_LENGTH }).map((_, index) => (
+                    <PinDot
+                      key={index}
+                      filled={index < pin.length}
+                      error={!!error && pin.length === PIN_LENGTH}
+                    />
+                  ))}
+                </View>
+              </View>
+            </View>
+
+            <View className="flex-1 justify-center items-center">
+              <View className="w-[75%] h-[75%] justify-center">
+                <NumericKeypad
+                  onKeyPress={handleKeyPress}
+                  onBackspace={handleBackspace}
+                />
+              </View>
+            </View>
+
+            <View className="px-6 pb-8">
+              <Pressable
+                className="bg-ui-border rounded-xl py-4 items-center"
+                onPress={handleClose}
+              >
+                <Text className="text-base font-semibold text-text-primary">
+                  Cancel
+                </Text>
+              </Pressable>
+            </View>
+          </View>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}

--- a/src/presentation/screens/guest-mode-screen.tsx
+++ b/src/presentation/screens/guest-mode-screen.tsx
@@ -1,11 +1,12 @@
 import { View, Text, ScrollView, Pressable, BackHandler } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import React, { useState, useEffect } from "react";
-import { useRouter } from "expo-router";
+import { useRouter, useLocalSearchParams } from "expo-router";
 import { DocumentRepositoryImpl } from "@data/repositories/document.repository.impl";
 import { Document } from "@domain/entities/document.entity";
 import { DocumentCard } from "@presentation/components/document-card";
 import { CountdownTimer } from "@presentation/components/countdown-timer";
+import { PinAuthBottomSheet } from "@presentation/components/pin-auth-bottom-sheet";
 import { SecureStorageAdapter } from "@infrastructure/storage/secure-storage.adapter";
 
 const AUTO_LOCK_TIMEOUT_KEY = "auto_lock_timeout_minutes";
@@ -16,9 +17,11 @@ const storage = new SecureStorageAdapter(
 
 export function GuestModeScreen() {
   const router = useRouter();
+  const params = useLocalSearchParams<{ docIds?: string }>();
   const [documents, setDocuments] = useState<Document[]>([]);
   const [timeoutMinutes, setTimeoutMinutes] = useState(5); // fallback de 5 minutos
   const [isLoading, setIsLoading] = useState(true);
+  const [showPinAuth, setShowPinAuth] = useState(false);
   const documentRepository = new DocumentRepositoryImpl();
 
   useEffect(() => {
@@ -56,10 +59,21 @@ export function GuestModeScreen() {
     try {
       setIsLoading(true);
       const allDocuments = await documentRepository.findAll();
-      const autoLockDocuments = allDocuments.filter(
-        (doc) => doc.isAutoLockEnabled === true,
-      );
-      setDocuments(autoLockDocuments);
+
+      // Filter by docIds if provided (from SelectDocumentsScreen)
+      if (params.docIds) {
+        const selectedIds = params.docIds.split(",");
+        const filteredDocuments = allDocuments.filter((doc) =>
+          selectedIds.includes(doc.id),
+        );
+        setDocuments(filteredDocuments);
+      } else {
+        // Fallback: use isAutoLockEnabled (backward compatibility)
+        const autoLockDocuments = allDocuments.filter(
+          (doc) => doc.isAutoLockEnabled === true,
+        );
+        setDocuments(autoLockDocuments);
+      }
     } catch (error) {
       console.error("Error loading documents:", error);
       setDocuments([]);
@@ -75,6 +89,15 @@ export function GuestModeScreen() {
   const handleTimerExpire = () => {
     // Navega para a tela de unlock sem possibilidade de voltar
     router.replace("/unlock");
+  };
+
+  const handleExitSecureMode = () => {
+    setShowPinAuth(true);
+  };
+
+  const handlePinAuthSuccess = () => {
+    setShowPinAuth(false);
+    router.replace("/(tabs)");
   };
 
   const renderEmptyState = () => (
@@ -112,20 +135,36 @@ export function GuestModeScreen() {
 
   const renderDocumentList = () => (
     <ScrollView className="flex-1" showsVerticalScrollIndicator={false}>
-      <View className="px-4 py-4">
+      <View className="px-6 py-4 gap-3">
         {documents.map((document) => (
           <Pressable
             key={document.id}
             onPress={() => handleDocumentPress(document.id)}
-            className="mb-4"
+            className="bg-background-secondary rounded-2xl p-4 active:opacity-80"
           >
-            <DocumentCard
-              type={document.type}
-              title={document.fullName}
-              subtitle={formatDocumentSubtitle(document)}
-              icon={getDocumentIcon(document.type)}
-              badge={document.isAutoLockEnabled ? "Auto-lock" : undefined}
-            />
+            <View className="flex-row items-start justify-between">
+              <View className="flex-row flex-1">
+                <View className="w-12 h-12 bg-primary-main/10 rounded-xl items-center justify-center mr-3">
+                  <Text className="text-2xl">{getDocumentIcon(document.type)}</Text>
+                </View>
+                <View className="flex-1">
+                  <Text className="text-base font-bold text-text-primary mb-1">
+                    {document.fullName}
+                  </Text>
+                  <View className="flex-row items-center">
+                    <Text className="text-xs text-text-secondary">
+                      DOCUMENT NUMBER
+                    </Text>
+                  </View>
+                  <Text className="text-sm text-text-secondary">
+                    •••• •••• {document.documentNumber.slice(-4)}
+                  </Text>
+                </View>
+              </View>
+              <View className="w-8 h-8 bg-primary-main/10 rounded-lg items-center justify-center ml-2">
+                <Text className="text-primary-main text-lg">📋</Text>
+              </View>
+            </View>
           </Pressable>
         ))}
       </View>
@@ -136,9 +175,19 @@ export function GuestModeScreen() {
     <SafeAreaView className="flex-1 bg-background-primary">
       {/* Header */}
       <View className="px-6 pt-6 pb-4 border-b border-border-primary">
-        <Text className="text-3xl font-bold text-text-primary mb-2">
-          Shared Documents
-        </Text>
+        <View className="flex-row items-center justify-between mb-4">
+          <Text className="text-3xl font-bold text-text-primary">
+            Shared Documents
+          </Text>
+          <Pressable
+            onPress={handleExitSecureMode}
+            className="bg-status-error/10 rounded-lg px-3 py-2 active:opacity-75"
+          >
+            <Text className="text-sm font-semibold text-status-error">
+              Sair
+            </Text>
+          </Pressable>
+        </View>
         <Text className="text-base text-text-secondary mb-4">
           Access expires in
         </Text>
@@ -159,6 +208,13 @@ export function GuestModeScreen() {
       ) : (
         renderDocumentList()
       )}
+
+      {/* PIN Auth Bottom Sheet */}
+      <PinAuthBottomSheet
+        visible={showPinAuth}
+        onSuccess={handlePinAuthSuccess}
+        onClose={() => setShowPinAuth(false)}
+      />
     </SafeAreaView>
   );
 }

--- a/src/presentation/screens/select-documents-screen.tsx
+++ b/src/presentation/screens/select-documents-screen.tsx
@@ -1,22 +1,60 @@
-import { View, Text, ScrollView, Pressable } from "react-native";
+import { View, Text, ScrollView, Pressable, Alert } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { SelectableDocumentItem } from "@presentation/components/selectable-document-item";
 import { useRouter } from "expo-router";
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { useDocuments } from "@presentation/hooks/use-documents";
 
 export function SelectDocumentsScreen() {
   const router = useRouter();
-  const [selectedDocs, setSelectedDocs] = useState<string[]>([
-    "passport",
-    "national-id",
-  ]);
+  const { documents, isLoading } = useDocuments();
+  const [selectedDocIds, setSelectedDocIds] = useState<string[]>([]);
+
+  useEffect(() => {
+    // Documents are loaded automatically by the useDocuments hook
+  }, []);
 
   const toggleDocument = (docId: string) => {
-    setSelectedDocs((prev) =>
+    setSelectedDocIds((prev) =>
       prev.includes(docId)
         ? prev.filter((id) => id !== docId)
         : [...prev, docId],
     );
+  };
+
+  const getDocumentIcon = (type: string) => {
+    switch (type) {
+      case "CNH":
+        return "🚗";
+      case "RG":
+        return "🆔";
+      default:
+        return "📄";
+    }
+  };
+
+  const getDocumentLabel = (type: string) => {
+    switch (type) {
+      case "CNH":
+        return "Driver's License";
+      case "RG":
+        return "National ID";
+      default:
+        return "Document";
+    }
+  };
+
+  const handleConfirm = () => {
+    if (selectedDocIds.length === 0) {
+      Alert.alert(
+        "Select at least one document",
+        "You need to select at least one document to enter Guest Mode.",
+        [{ text: "OK" }]
+      );
+      return;
+    }
+
+    router.push(`/guest-mode?docIds=${selectedDocIds.join(',')}`);
   };
 
   return (
@@ -47,34 +85,29 @@ export function SelectDocumentsScreen() {
             </Text>
 
             <View className="mb-6">
-              <SelectableDocumentItem
-                icon="📖"
-                title="Passport"
-                subtitle="United States • **** 4589"
-                selected={selectedDocs.includes("passport")}
-                onToggle={() => toggleDocument("passport")}
-              />
-              <SelectableDocumentItem
-                icon="🆔"
-                title="National Identity Card"
-                subtitle="Expires: 12/2028"
-                selected={selectedDocs.includes("national-id")}
-                onToggle={() => toggleDocument("national-id")}
-              />
-              <SelectableDocumentItem
-                icon="🏥"
-                title="Health Insurance Card"
-                subtitle="Provider: BlueShield Premium"
-                selected={selectedDocs.includes("health-insurance")}
-                onToggle={() => toggleDocument("health-insurance")}
-              />
-              <SelectableDocumentItem
-                icon="🛡️"
-                title="Travel Insurance"
-                subtitle="Policy No: TRV-99201-B"
-                selected={selectedDocs.includes("travel-insurance")}
-                onToggle={() => toggleDocument("travel-insurance")}
-              />
+              {isLoading ? (
+                <Text className="text-text-secondary text-center py-8">
+                  Loading documents...
+                </Text>
+              ) : documents.length === 0 ? (
+                <View className="items-center justify-center py-12">
+                  <Text className="text-6xl mb-4">📄</Text>
+                  <Text className="text-base md:text-lg text-text-secondary mb-6 text-center">
+                    No documents registered. Add documents in the main app first.
+                  </Text>
+                </View>
+              ) : (
+                documents.map((doc) => (
+                  <SelectableDocumentItem
+                    key={doc.id}
+                    icon={getDocumentIcon(doc.type)}
+                    title={doc.fullName}
+                    subtitle={`${getDocumentLabel(doc.type)} • **** ${doc.documentNumber.slice(-4)}`}
+                    selected={selectedDocIds.includes(doc.id)}
+                    onToggle={() => toggleDocument(doc.id)}
+                  />
+                ))
+              )}
             </View>
 
             <View className="bg-primary-main/10 rounded-2xl p-4 md:p-5 mb-6 border border-primary-main/20">
@@ -99,7 +132,7 @@ export function SelectDocumentsScreen() {
                 <Text className="text-base md:text-lg font-semibold text-text-primary">
                   You are sharing{" "}
                   <Text className="text-primary-main">
-                    {selectedDocs.length}
+                    {selectedDocIds.length}
                   </Text>{" "}
                   documents
                 </Text>
@@ -111,9 +144,7 @@ export function SelectDocumentsScreen() {
         <View className="px-6 pb-6 pt-4 bg-background-primary border-t border-ui-border">
           <Pressable
             className="bg-primary-main rounded-xl py-4 items-center active:opacity-90"
-            onPress={() => {
-              router.back();
-            }}
+            onPress={handleConfirm}
           >
             <Text className="text-base md:text-lg font-bold text-text-primary">
               Confirm & Lock App


### PR DESCRIPTION
## TASK-6: GuestModeScreen Improvements

### Changes
- **New Component:** PinAuthBottomSheet with 6-digit PIN input validation
- **Updated GuestModeScreen:**
  - Accept docIds from route params (/guest-mode?docIds=id1,id2,id3)
  - Display only selected documents
  - Add 'Sair do Modo Seguro' exit button with PIN validation
  - Improved card layout (matches WalletHomeScreen style)
  - Backward compatibility: fallback to isAutoLockEnabled if docIds missing

### Checklist
- ✅ GuestMode displays exactly selected documents
- ✅ Exit button visible in header
- ✅ PIN validation opens in bottom sheet
- ✅ Correct PIN → back to home
- ✅ Incorrect PIN → error shown, stays in GuestMode
- ✅ Card layout consistent with WalletHomeScreen
- ✅ Hardware back button still blocked
- ✅ Timer continues working

Closes #150