### PR TITLE
refactor(theme): consolidate design tokens and remove hardcoded hex values

### DIFF
--- a/src/presentation/components/add-contact-bottom-sheet.tsx
+++ b/src/presentation/components/add-contact-bottom-sheet.tsx
@@ -10,6 +10,7 @@ import {
 } from "react-native";
 import { useState } from "react";
 import { EmergencyContact } from "@domain/entities/emergency-info.entity";
+import { tokens } from "@presentation/theme/design-tokens";
 
 interface AddContactBottomSheetProps {
   visible: boolean;
@@ -109,7 +110,7 @@ export function AddContactBottomSheet({
                   <TextInput
                     className="bg-light-bgSecondary dark:bg-background-secondary rounded-xl px-4 py-3 text-light-text dark:text-text-primary"
                     placeholder="Enter full name"
-                    placeholderTextColor="#64748B"
+                    placeholderTextColor={tokens.colors.text.tertiary}
                     value={fullName}
                     onChangeText={setFullName}
                   />
@@ -122,7 +123,7 @@ export function AddContactBottomSheet({
                   <TextInput
                     className="bg-light-bgSecondary dark:bg-background-secondary rounded-xl px-4 py-3 text-light-text dark:text-text-primary"
                     placeholder="e.g. Spouse, Parent, Sibling"
-                    placeholderTextColor="#64748B"
+                    placeholderTextColor={tokens.colors.text.tertiary}
                     value={relationship}
                     onChangeText={setRelationship}
                   />
@@ -135,7 +136,7 @@ export function AddContactBottomSheet({
                   <TextInput
                     className="bg-light-bgSecondary dark:bg-background-secondary rounded-xl px-4 py-3 text-light-text dark:text-text-primary"
                     placeholder="+1 (555) 0123"
-                    placeholderTextColor="#64748B"
+                    placeholderTextColor={tokens.colors.text.tertiary}
                     keyboardType="phone-pad"
                     value={phoneNumber}
                     onChangeText={setPhoneNumber}

--- a/src/presentation/components/camera-scanner.tsx
+++ b/src/presentation/components/camera-scanner.tsx
@@ -2,6 +2,7 @@ import { Pressable, Text, View, StyleSheet } from "react-native";
 import { Hourglass, Camera } from "lucide-react-native";
 import { CameraView, useCameraPermissions } from "expo-camera";
 import { useEffect, useRef, useState } from "react";
+import { tokens } from "@presentation/theme/design-tokens";
 
 let TextRecognition: any = null;
 try {
@@ -140,9 +141,17 @@ export function CameraScanner({ onCardDataExtracted }: CameraScannerProps) {
               disabled={isScanning}
             >
               {isScanning ? (
-                <Hourglass size={18} color="#FFFFFF" className="mr-2" />
+                <Hourglass
+                  size={18}
+                  color={tokens.colors.text.primary}
+                  className="mr-2"
+                />
               ) : (
-                <Camera size={18} color="#FFFFFF" className="mr-2" />
+                <Camera
+                  size={18}
+                  color={tokens.colors.text.primary}
+                  className="mr-2"
+                />
               )}
               <Text className="text-base font-bold text-text-primary">
                 {isScanning ? "Scanning..." : "Scan Card"}

--- a/src/presentation/components/checkbox-option.tsx
+++ b/src/presentation/components/checkbox-option.tsx
@@ -1,5 +1,6 @@
 import { View, Text, Pressable } from "react-native";
 import { Check } from "lucide-react-native";
+import { tokens } from "@presentation/theme/design-tokens";
 
 interface CheckboxOptionProps {
   label: string;
@@ -21,7 +22,7 @@ export function CheckboxOption({
             : "bg-transparent border-2 border-ui-border"
         }`}
       >
-        {checked && <Check size={14} color="#FFFFFF" />}
+        {checked && <Check size={14} color={tokens.colors.text.primary} />}
       </View>
       <Text className="text-sm text-text-primary flex-1">{label}</Text>
     </Pressable>

--- a/src/presentation/components/contact-card.tsx
+++ b/src/presentation/components/contact-card.tsx
@@ -1,5 +1,6 @@
 import { View, Text, Pressable } from "react-native";
 import { X, ChevronRight, Phone } from "lucide-react-native";
+import { tokens } from "@presentation/theme/design-tokens";
 
 interface ContactCardProps {
   fullName: string;
@@ -43,7 +44,7 @@ export function ContactCard({
             className="w-8 h-8 items-center justify-center"
             onPress={onRemove}
           >
-            <X size={18} color="#EF4444" />
+            <X size={18} color={tokens.colors.status.error} />
           </Pressable>
         )}
       </View>
@@ -57,7 +58,11 @@ export function ContactCard({
             <Text className="text-sm text-light-text dark:text-text-primary">
               {relationship}
             </Text>
-            <ChevronRight size={16} color="#94A3B8" className="ml-1" />
+            <ChevronRight
+              size={16}
+              color={tokens.colors.text.secondary}
+              className="ml-1"
+            />
           </View>
         </View>
 
@@ -73,7 +78,7 @@ export function ContactCard({
               className="w-8 h-8 bg-status-success/20 rounded-full items-center justify-center"
               onPress={onCall}
             >
-              <Phone size={14} color="#10B981" />
+              <Phone size={14} color={tokens.colors.status.success} />
             </Pressable>
           </View>
         </View>

--- a/src/presentation/components/credit-card-preview.tsx
+++ b/src/presentation/components/credit-card-preview.tsx
@@ -1,5 +1,6 @@
 import { View, Text } from "react-native";
 import { Wifi } from "lucide-react-native";
+import { tokens } from "@presentation/theme/design-tokens";
 
 interface CreditCardPreviewProps {
   cardNumber?: string;
@@ -15,7 +16,7 @@ export function CreditCardPreview({
   return (
     <View className="bg-gradient-to-br from-primary-main to-primary-dark rounded-2xl p-6 mb-6">
       <View className="mb-8">
-        <Wifi size={28} color="#FFFFFF" className="mb-2" />
+        <Wifi size={28} color={tokens.colors.text.primary} className="mb-2" />
       </View>
 
       <View className="mb-6">

--- a/src/presentation/components/date-input.tsx
+++ b/src/presentation/components/date-input.tsx
@@ -1,5 +1,6 @@
 import { View, Text, Pressable, TextInput } from "react-native";
 import { Calendar } from "lucide-react-native";
+import { tokens } from "@presentation/theme/design-tokens";
 
 interface DateInputProps {
   label: string;
@@ -25,7 +26,7 @@ export function DateInput({
         <TextInput
           className="flex-1 text-light-text dark:text-text-primary"
           placeholder={placeholder}
-          placeholderTextColor="#64748B"
+          placeholderTextColor={tokens.colors.text.tertiary}
           value={value}
           onChangeText={onChangeText}
           keyboardType="number-pad"
@@ -35,7 +36,7 @@ export function DateInput({
           className="ml-2 w-8 h-8 items-center justify-center active:opacity-60"
           onPress={onPress}
         >
-          <Calendar size={20} color="#94A3B8" />
+          <Calendar size={20} color={tokens.colors.text.secondary} />
         </Pressable>
       </View>
     </View>

--- a/src/presentation/components/dropdown-input.tsx
+++ b/src/presentation/components/dropdown-input.tsx
@@ -1,6 +1,7 @@
 import { View, Text, Pressable, Modal } from "react-native";
 import { useState } from "react";
 import { ChevronRight, Pencil } from "lucide-react-native";
+import { tokens } from "@presentation/theme/design-tokens";
 
 interface DropdownOption {
   label: string;
@@ -47,7 +48,7 @@ export function DropdownInput({
         >
           {selectedLabel || placeholder}
         </Text>
-        <ChevronRight size={20} color="#94A3B8" />
+        <ChevronRight size={20} color={tokens.colors.text.secondary} />
       </Pressable>
 
       <Modal visible={showOptions} transparent animationType="slide">
@@ -92,7 +93,7 @@ export function DropdownInput({
                       onEditOption(option.value);
                     }}
                   >
-                    <Pencil size={14} color="#135BEC" />
+                    <Pencil size={14} color={tokens.colors.primary.main} />
                   </Pressable>
                 )}
               </View>

--- a/src/presentation/components/info-banner.tsx
+++ b/src/presentation/components/info-banner.tsx
@@ -1,6 +1,7 @@
 import { View, Text } from "react-native";
 import { ReactNode } from "react";
 import { Info } from "lucide-react-native";
+import { tokens } from "@presentation/theme/design-tokens";
 
 interface InfoBannerProps {
   message: string;
@@ -9,7 +10,7 @@ interface InfoBannerProps {
 
 export function InfoBanner({
   message,
-  icon = <Info size={18} color="#94A3B8" />,
+  icon = <Info size={18} color={tokens.colors.text.secondary} />,
 }: InfoBannerProps) {
   return (
     <View className="bg-light-bgSecondary dark:bg-background-secondary rounded-xl p-4 flex-row">

--- a/src/presentation/components/photo-upload.tsx
+++ b/src/presentation/components/photo-upload.tsx
@@ -1,5 +1,6 @@
 import { View, Text, Pressable, Image } from "react-native";
 import { Camera } from "lucide-react-native";
+import { tokens } from "@presentation/theme/design-tokens";
 
 interface PhotoUploadProps {
   title: string;
@@ -44,7 +45,7 @@ export function PhotoUpload({
       ) : (
         <>
           <View className="w-16 h-16 bg-primary-main/20 rounded-full items-center justify-center mb-3">
-            <Camera size={28} color="#135BEC" />
+            <Camera size={28} color={tokens.colors.primary.main} />
           </View>
           <Text className="text-base font-semibold text-light-text dark:text-text-primary mb-1">
             {title}

--- a/src/presentation/components/pin-auth-bottom-sheet.tsx
+++ b/src/presentation/components/pin-auth-bottom-sheet.tsx
@@ -8,6 +8,7 @@ import { SecureStorageAdapter } from "@infrastructure/storage/secure-storage.ada
 import { useBiometry } from "@presentation/hooks/use-biometry";
 import { useTranslation } from "react-i18next";
 import { Fingerprint } from "lucide-react-native";
+import { tokens } from "@presentation/theme/design-tokens";
 
 const BIOMETRY_ENABLED_KEY = "biometry_enabled";
 const settingsStorage = new SecureStorageAdapter(
@@ -205,7 +206,7 @@ export function PinAuthBottomSheet({
                   className="bg-primary-main rounded-xl py-4 flex-row items-center justify-center active:bg-primary-dark"
                   onPress={handleBiometryAuth}
                 >
-                  <Fingerprint size={20} color="#FFFFFF" />
+                  <Fingerprint size={20} color={tokens.colors.text.primary} />
                   <Text className="text-base font-semibold text-white ml-2">
                     {getBiometryName()}
                   </Text>

--- a/src/presentation/components/search-bar.tsx
+++ b/src/presentation/components/search-bar.tsx
@@ -1,4 +1,5 @@
 import { View, TextInput } from "react-native";
+import { tokens } from "@presentation/theme/design-tokens";
 
 interface SearchBarProps {
   placeholder?: string;
@@ -22,7 +23,7 @@ export function SearchBar({
       <TextInput
         className="flex-1 text-base text-text-secondary"
         placeholder={placeholder}
-        placeholderTextColor="#64748B"
+        placeholderTextColor={tokens.colors.text.tertiary}
         value={value}
         onChangeText={onChangeText}
       />

--- a/src/presentation/components/section-header.tsx
+++ b/src/presentation/components/section-header.tsx
@@ -1,6 +1,8 @@
 import { View, Text } from "react-native";
 import { ReactNode } from "react";
 
+import { tokens } from "@presentation/theme/design-tokens";
+
 interface SectionHeaderProps {
   icon: ReactNode;
   title: string;
@@ -10,7 +12,7 @@ interface SectionHeaderProps {
 export function SectionHeader({
   icon,
   title,
-  iconBg = "#3B82F6",
+  iconBg = tokens.colors.status.info,
 }: SectionHeaderProps) {
   return (
     <View className="flex-row items-center mb-4">

--- a/src/presentation/components/selectable-document-item.tsx
+++ b/src/presentation/components/selectable-document-item.tsx
@@ -1,5 +1,6 @@
 import { View, Text, Pressable } from "react-native";
 import { Check } from "lucide-react-native";
+import { tokens } from "@presentation/theme/design-tokens";
 
 interface SelectableDocumentItemProps {
   icon: string;
@@ -31,7 +32,7 @@ export function SelectableDocumentItem({
               : "border-light-border dark:border-ui-border"
           }`}
         >
-          {selected && <Check size={14} color="#FFFFFF" />}
+          {selected && <Check size={14} color={tokens.colors.text.primary} />}
         </View>
 
         <View className="flex-1">

--- a/src/presentation/components/settings-item.tsx
+++ b/src/presentation/components/settings-item.tsx
@@ -1,5 +1,6 @@
 import { View, Text, Pressable, Switch, ActivityIndicator } from "react-native";
 import { ReactNode } from "react";
+import { tokens } from "@presentation/theme/design-tokens";
 
 interface SettingsItemProps {
   label: string;
@@ -61,14 +62,25 @@ export function SettingsItem({
               value={switchValue}
               onValueChange={onSwitchChange}
               disabled={disabled || loading}
-              trackColor={{ false: "#767577", true: "#3B82F6" }}
-              thumbColor={switchValue ? "#FFFFFF" : "#f4f3f4"}
+              trackColor={{
+                false: tokens.colors.text.tertiary,
+                true: tokens.colors.status.info,
+              }}
+              thumbColor={
+                switchValue
+                  ? tokens.colors.text.primary
+                  : tokens.colors.background.tertiary
+              }
             />
             {loading && (
               <View className="absolute inset-0 items-center justify-center bg-black/10 rounded-full">
                 <ActivityIndicator
                   size="small"
-                  color={destructive ? "#EF4444" : "#3B82F6"}
+                  color={
+                    destructive
+                      ? tokens.colors.status.error
+                      : tokens.colors.status.info
+                  }
                 />
               </View>
             )}

--- a/src/presentation/components/text-input-field.tsx
+++ b/src/presentation/components/text-input-field.tsx
@@ -1,4 +1,5 @@
 import { View, Text, TextInput } from "react-native";
+import { tokens } from "@presentation/theme/design-tokens";
 
 interface TextInputFieldProps {
   label: string;
@@ -23,7 +24,7 @@ export function TextInputField({
       <TextInput
         className="bg-light-bgSecondary dark:bg-background-secondary rounded-xl px-4 py-4 text-light-text dark:text-text-primary"
         placeholder={placeholder}
-        placeholderTextColor="#64748B"
+        placeholderTextColor={tokens.colors.text.tertiary}
         value={value}
         onChangeText={onChangeText}
         keyboardType={keyboardType}

--- a/src/presentation/components/themed-text.tsx
+++ b/src/presentation/components/themed-text.tsx
@@ -1,6 +1,7 @@
 import { StyleSheet, Text, type TextProps } from "react-native";
 
 import { useThemeColor } from "@presentation/hooks/use-theme-color";
+import { tokens } from "@presentation/theme/design-tokens";
 
 export type ThemedTextProps = TextProps & {
   lightColor?: string;
@@ -55,6 +56,6 @@ const styles = StyleSheet.create({
   link: {
     lineHeight: 30,
     fontSize: 16,
-    color: "#0a7ea4",
+    color: tokens.colors.primary.main,
   },
 });

--- a/src/presentation/components/user-avatar.tsx
+++ b/src/presentation/components/user-avatar.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { View, Image, Pressable, ActivityIndicator, Text } from "react-native";
 import { User } from "lucide-react-native";
+import { tokens } from "@presentation/theme/design-tokens";
 
 interface UserAvatarProps {
   photoUri?: string | null;
@@ -30,7 +31,7 @@ export function UserAvatar({
         />
       ) : (
         <View className="w-full h-full bg-primary-main/20 items-center justify-center">
-          <User size={28} color="#135BEC" />
+          <User size={28} color={tokens.colors.primary.main} />
         </View>
       )}
 

--- a/src/presentation/screens/add-credit-card-screen.tsx
+++ b/src/presentation/screens/add-credit-card-screen.tsx
@@ -25,6 +25,7 @@ import {
   CreditCard,
   Lock,
 } from "lucide-react-native";
+import { tokens } from "@presentation/theme/design-tokens";
 
 export function AddCreditCardScreen() {
   const router = useRouter();
@@ -209,7 +210,7 @@ export function AddCreditCardScreen() {
             className="w-10 h-10 items-center justify-center"
             onPress={() => router.back()}
           >
-            <ChevronLeft size={24} color="#94A3B8" />
+            <ChevronLeft size={24} color={tokens.colors.text.secondary} />
           </Pressable>
           <Text className="text-lg font-bold text-light-text dark:text-text-primary">
             {cards.length > 0 && isEditMode ? "Credit Card" : "New Credit Card"}
@@ -254,7 +255,7 @@ export function AddCreditCardScreen() {
                     onPress={handleDeleteCard}
                     disabled={isLoading}
                   >
-                    <Trash2 size={20} color="#EF4444" />
+                    <Trash2 size={20} color={tokens.colors.status.error} />
                   </Pressable>
                 )}
               </View>
@@ -272,12 +273,16 @@ export function AddCreditCardScreen() {
                   <TextInput
                     className="flex-1 text-light-text dark:text-text-primary"
                     placeholder="e.g. JONATHAN DOE"
-                    placeholderTextColor="#64748B"
+                    placeholderTextColor={tokens.colors.text.tertiary}
                     value={cardholderName}
                     onChangeText={handleCardholderNameChange}
                     autoCapitalize="characters"
                   />
-                  <User size={20} color="#135BEC" className="ml-2" />
+                  <User
+                    size={20}
+                    color={tokens.colors.primary.main}
+                    className="ml-2"
+                  />
                 </View>
               </View>
 
@@ -289,14 +294,18 @@ export function AddCreditCardScreen() {
                   <TextInput
                     className="flex-1 text-light-text dark:text-text-primary"
                     placeholder="0000 0000 0000 0000"
-                    placeholderTextColor="#64748B"
+                    placeholderTextColor={tokens.colors.text.tertiary}
                     keyboardType="number-pad"
                     inputMode="numeric"
                     value={cardNumber}
                     onChangeText={handleCardNumberChange}
                     maxLength={19}
                   />
-                  <CreditCard size={20} color="#135BEC" className="ml-2" />
+                  <CreditCard
+                    size={20}
+                    color={tokens.colors.primary.main}
+                    className="ml-2"
+                  />
                 </View>
               </View>
 
@@ -307,7 +316,7 @@ export function AddCreditCardScreen() {
                 <TextInput
                   className="bg-light-bgSecondary dark:bg-background-secondary rounded-xl px-4 py-4 text-light-text dark:text-text-primary"
                   placeholder="MM/YY"
-                  placeholderTextColor="#64748B"
+                  placeholderTextColor={tokens.colors.text.tertiary}
                   keyboardType="number-pad"
                   inputMode="numeric"
                   value={expiryDate}
@@ -332,7 +341,11 @@ export function AddCreditCardScreen() {
               onPress={handleSaveCard}
               disabled={isLoading || (isEditMode && !hasChanges())}
             >
-              <Lock size={18} color="#FFFFFF" className="mr-2" />
+              <Lock
+                size={18}
+                color={tokens.colors.text.primary}
+                className="mr-2"
+              />
               <Text className="text-base font-bold text-light-text dark:text-text-primary">
                 {isLoading
                   ? "Saving..."

--- a/src/presentation/screens/add-document-screen.tsx
+++ b/src/presentation/screens/add-document-screen.tsx
@@ -16,6 +16,7 @@ import { DocumentTypeDefinition } from "@domain/entities/document-type-definitio
 import { useDocumentsStore } from "@stores/documents.store";
 import { useTranslation } from "react-i18next";
 import { ChevronLeft, Trash2, Lock } from "lucide-react-native";
+import { tokens } from "@presentation/theme/design-tokens";
 
 export function AddDocumentScreen() {
   const { t } = useTranslation();
@@ -192,7 +193,7 @@ export function AddDocumentScreen() {
             className="w-10 h-10 items-center justify-center"
             onPress={() => router.back()}
           >
-            <ChevronLeft size={24} color="#94A3B8" />
+            <ChevronLeft size={24} color={tokens.colors.text.secondary} />
           </Pressable>
           <Text className="text-lg font-bold text-light-text dark:text-text-primary">
             {isEditMode ? t("addDocument.editTitle") : t("addDocument.title")}
@@ -203,7 +204,7 @@ export function AddDocumentScreen() {
               onPress={handleDeleteDocument}
               disabled={isLoading}
             >
-              <Trash2 size={20} color="#EF4444" />
+              <Trash2 size={20} color={tokens.colors.status.error} />
             </Pressable>
           ) : (
             <View className="w-10" />
@@ -245,7 +246,7 @@ export function AddDocumentScreen() {
           <View className="flex-row bg-primary-main/10 rounded-xl p-4 mb-6">
             <View className="mr-3">
               <View className="w-6 h-6 bg-primary-main rounded-full items-center justify-center">
-                <Lock size={12} color="#FFFFFF" />
+                <Lock size={12} color={tokens.colors.text.primary} />
               </View>
             </View>
             <Text className="flex-1 text-sm text-light-textSecondary dark:text-text-secondary leading-5">

--- a/src/presentation/screens/document-details-screen.tsx
+++ b/src/presentation/screens/document-details-screen.tsx
@@ -21,6 +21,7 @@ import { getDocumentTypeById } from "@domain/entities/document-type-registry";
 import { useDocumentsStore } from "@stores/documents.store";
 import { useTranslation } from "react-i18next";
 import { ChevronLeft, Pencil, X, Lock } from "lucide-react-native";
+import { tokens } from "@presentation/theme/design-tokens";
 
 export function DocumentDetailsScreen() {
   const { t } = useTranslation();
@@ -106,7 +107,7 @@ export function DocumentDetailsScreen() {
         edges={["top"]}
       >
         <View className="flex-1 items-center justify-center">
-          <ActivityIndicator size="large" color="#3B82F6" />
+          <ActivityIndicator size="large" color={tokens.colors.status.info} />
         </View>
       </SafeAreaView>
     );
@@ -147,7 +148,7 @@ export function DocumentDetailsScreen() {
               }
             }}
           >
-            <ChevronLeft size={24} color="#94A3B8" />
+            <ChevronLeft size={24} color={tokens.colors.text.secondary} />
           </Pressable>
           <Text className="text-lg font-bold text-light-text dark:text-text-primary">
             {document.typeName ?? typeDef?.label ?? "Documento"}
@@ -162,7 +163,7 @@ export function DocumentDetailsScreen() {
                 })
               }
             >
-              <Pencil size={20} color="#135BEC" />
+              <Pencil size={20} color={tokens.colors.primary.main} />
             </Pressable>
           )}
         </View>
@@ -242,7 +243,10 @@ export function DocumentDetailsScreen() {
                   </View>
                   <View>
                     {isTogglingAutoLock ? (
-                      <ActivityIndicator size="small" color="#3B82F6" />
+                      <ActivityIndicator
+                        size="small"
+                        color={tokens.colors.status.info}
+                      />
                     ) : (
                       <Pressable
                         onPress={handleToggleAutoLock}
@@ -267,7 +271,7 @@ export function DocumentDetailsScreen() {
 
           <View className="px-6">
             <InfoBanner
-              icon={<Lock size={18} color="#94A3B8" />}
+              icon={<Lock size={18} color={tokens.colors.text.secondary} />}
               message={t("documentDetails.encryptionNotice")}
             />
           </View>
@@ -308,7 +312,7 @@ export function DocumentDetailsScreen() {
             className="absolute top-14 right-6 w-10 h-10 bg-white/20 rounded-full items-center justify-center"
             onPress={() => setFullscreenPhoto(null)}
           >
-            <X size={20} color="#FFFFFF" />
+            <X size={20} color={tokens.colors.text.primary} />
           </Pressable>
         </Pressable>
       </Modal>

--- a/src/presentation/screens/documents-screen.tsx
+++ b/src/presentation/screens/documents-screen.tsx
@@ -9,6 +9,7 @@ import {
 import { useDocumentsStore } from "@stores/documents.store";
 import { useTranslation } from "react-i18next";
 import { FileText, ChevronRight } from "lucide-react-native";
+import { tokens } from "@presentation/theme/design-tokens";
 
 export function DocumentsScreen() {
   const { t } = useTranslation();
@@ -29,7 +30,11 @@ export function DocumentsScreen() {
 
           {documents.length === 0 ? (
             <View className="items-center justify-center py-12">
-              <FileText size={48} color="#94A3B8" className="mb-4" />
+              <FileText
+                size={48}
+                color={tokens.colors.text.secondary}
+                className="mb-4"
+              />
               <Text className="text-base md:text-lg text-light-textSecondary dark:text-text-secondary mb-6 text-center">
                 {t("documents.noDocuments")}
               </Text>
@@ -70,7 +75,10 @@ export function DocumentsScreen() {
                         {doc.fields.fullName ?? doc.fields.documentNumber ?? ""}
                       </Text>
                     </View>
-                    <ChevronRight size={20} color="#94A3B8" />
+                    <ChevronRight
+                      size={20}
+                      color={tokens.colors.text.secondary}
+                    />
                   </Pressable>
                 ))}
               </View>

--- a/src/presentation/screens/emergency-details-screen.tsx
+++ b/src/presentation/screens/emergency-details-screen.tsx
@@ -26,6 +26,7 @@ import {
   User,
   Phone,
 } from "lucide-react-native";
+import { tokens } from "@presentation/theme/design-tokens";
 
 interface Props {
   isAuthenticated?: boolean;
@@ -68,7 +69,7 @@ export function EmergencyDetailsScreen({ isAuthenticated = true }: Props) {
   if (isLoading) {
     return (
       <SafeAreaView className="flex-1 bg-light-bg dark:bg-background-primary items-center justify-center">
-        <ActivityIndicator size="large" color="#3B82F6" />
+        <ActivityIndicator size="large" color={tokens.colors.status.info} />
       </SafeAreaView>
     );
   }
@@ -85,7 +86,7 @@ export function EmergencyDetailsScreen({ isAuthenticated = true }: Props) {
               className="w-10 h-10 items-center justify-center"
               onPress={() => router.back()}
             >
-              <ChevronLeft size={24} color="#94A3B8" />
+              <ChevronLeft size={24} color={tokens.colors.text.secondary} />
             </Pressable>
             <Text className="text-lg font-bold text-light-text dark:text-text-primary">
               {t("emergency.title")}
@@ -95,7 +96,7 @@ export function EmergencyDetailsScreen({ isAuthenticated = true }: Props) {
                 className="w-10 h-10 items-center justify-center"
                 onPress={handleEditPress}
               >
-                <Pencil size={20} color="#135BEC" />
+                <Pencil size={20} color={tokens.colors.primary.main} />
               </Pressable>
             ) : (
               <View className="w-10" />
@@ -103,7 +104,11 @@ export function EmergencyDetailsScreen({ isAuthenticated = true }: Props) {
           </View>
 
           <View className="flex-1 items-center justify-center px-6">
-            <Siren size={24} color="#EF4444" className="mb-2" />
+            <Siren
+              size={24}
+              color={tokens.colors.status.error}
+              className="mb-2"
+            />
             <Text className="text-lg font-bold text-light-text dark:text-text-primary mb-2 text-center">
               {t("emergency.noInfo")}
             </Text>
@@ -137,7 +142,7 @@ export function EmergencyDetailsScreen({ isAuthenticated = true }: Props) {
             className="w-10 h-10 items-center justify-center"
             onPress={() => router.back()}
           >
-            <ChevronLeft size={24} color="#94A3B8" />
+            <ChevronLeft size={24} color={tokens.colors.text.secondary} />
           </Pressable>
           <Text className="text-lg font-bold text-light-text dark:text-text-primary">
             {t("emergency.title")}
@@ -147,7 +152,7 @@ export function EmergencyDetailsScreen({ isAuthenticated = true }: Props) {
               className="w-10 h-10 items-center justify-center"
               onPress={handleEditPress}
             >
-              <Pencil size={20} color="#135BEC" />
+              <Pencil size={20} color={tokens.colors.primary.main} />
             </Pressable>
           ) : (
             <View className="w-10" />
@@ -159,7 +164,11 @@ export function EmergencyDetailsScreen({ isAuthenticated = true }: Props) {
             {emergencyInfo.lockScreenVisible && (
               <View className="bg-primary-main/10 rounded-2xl p-4 mb-6 border border-primary-main/30">
                 <View className="flex-row items-start">
-                  <Info size={20} color="#135BEC" className="mr-2" />
+                  <Info
+                    size={20}
+                    color={tokens.colors.primary.main}
+                    className="mr-2"
+                  />
                   <View className="flex-1">
                     <Text className="text-sm font-bold text-primary-main mb-1">
                       {t("emergency.lockScreenAccess")}
@@ -175,7 +184,7 @@ export function EmergencyDetailsScreen({ isAuthenticated = true }: Props) {
             <View className="mb-6">
               <View className="flex-row items-center mb-4">
                 <View className="w-8 h-8 bg-status-error/20 rounded-lg items-center justify-center mr-2">
-                  <Asterisk size={18} color="#EF4444" />
+                  <Asterisk size={18} color={tokens.colors.status.error} />
                 </View>
                 <Text className="text-xs font-bold text-status-error tracking-wider">
                   {t("emergency.vitalInfo")}
@@ -186,7 +195,7 @@ export function EmergencyDetailsScreen({ isAuthenticated = true }: Props) {
                 {emergencyInfo.bloodType && (
                   <View className="flex-1 bg-light-bgSecondary dark:bg-background-secondary rounded-xl p-4">
                     <View className="w-10 h-10 bg-status-error/20 rounded-lg items-center justify-center mb-3">
-                      <Droplet size={24} color="#EF4444" />
+                      <Droplet size={24} color={tokens.colors.status.error} />
                     </View>
                     <Text className="text-xs font-semibold text-light-textSecondary dark:text-text-secondary mb-1 tracking-wide">
                       {t("emergency.bloodType")}
@@ -200,7 +209,10 @@ export function EmergencyDetailsScreen({ isAuthenticated = true }: Props) {
                 {emergencyInfo.healthPlan && (
                   <View className="flex-1 bg-light-bgSecondary dark:bg-background-secondary rounded-xl p-4">
                     <View className="w-10 h-10 bg-primary-main/20 rounded-lg items-center justify-center mb-3">
-                      <ShieldCheck size={24} color="#135BEC" />
+                      <ShieldCheck
+                        size={24}
+                        color={tokens.colors.primary.main}
+                      />
                     </View>
                     <Text className="text-xs font-semibold text-light-textSecondary dark:text-text-secondary mb-1 tracking-wide">
                       {t("emergency.healthPlan")}
@@ -216,7 +228,10 @@ export function EmergencyDetailsScreen({ isAuthenticated = true }: Props) {
                 <View className="bg-light-bgSecondary dark:bg-background-secondary rounded-xl p-4 mb-3">
                   <View className="flex-row items-center mb-3">
                     <View className="w-10 h-10 bg-accent-orange/20 rounded-lg items-center justify-center mr-3">
-                      <AlertTriangle size={24} color="#F59E0B" />
+                      <AlertTriangle
+                        size={24}
+                        color={tokens.colors.status.warning}
+                      />
                     </View>
                     <Text className="text-base font-bold text-light-text dark:text-text-primary">
                       {t("emergency.allergies")}
@@ -232,7 +247,7 @@ export function EmergencyDetailsScreen({ isAuthenticated = true }: Props) {
                 <View className="bg-light-bgSecondary dark:bg-background-secondary rounded-xl p-4 mb-3">
                   <View className="flex-row items-center mb-3">
                     <View className="w-10 h-10 bg-primary-main/20 rounded-lg items-center justify-center mr-3">
-                      <Hospital size={24} color="#135BEC" />
+                      <Hospital size={24} color={tokens.colors.primary.main} />
                     </View>
                     <Text className="text-base font-bold text-light-text dark:text-text-primary">
                       {t("emergency.healthConditions")}
@@ -248,7 +263,7 @@ export function EmergencyDetailsScreen({ isAuthenticated = true }: Props) {
                 <View className="bg-light-bgSecondary dark:bg-background-secondary rounded-xl p-4">
                   <View className="flex-row items-center mb-3">
                     <View className="w-10 h-10 bg-accent-green/20 rounded-lg items-center justify-center mr-3">
-                      <Pill size={24} color="#10B981" />
+                      <Pill size={24} color={tokens.colors.status.success} />
                     </View>
                     <Text className="text-base font-bold text-light-text dark:text-text-primary">
                       {t("emergency.medications")}
@@ -290,7 +305,10 @@ export function EmergencyDetailsScreen({ isAuthenticated = true }: Props) {
                           {index === 0 ? (
                             <View className="w-12 h-12 rounded-full overflow-hidden mr-3">
                               <View className="w-full h-full bg-primary-main/20 items-center justify-center">
-                                <User size={20} color="#135BEC" />
+                                <User
+                                  size={20}
+                                  color={tokens.colors.primary.main}
+                                />
                               </View>
                             </View>
                           ) : (
@@ -321,7 +339,7 @@ export function EmergencyDetailsScreen({ isAuthenticated = true }: Props) {
                             )
                           }
                         >
-                          <Phone size={24} color="#FFFFFF" />
+                          <Phone size={24} color={tokens.colors.text.primary} />
                         </Pressable>
                       </View>
                     </Pressable>

--- a/src/presentation/screens/emergency-setup-screen.tsx
+++ b/src/presentation/screens/emergency-setup-screen.tsx
@@ -30,6 +30,7 @@ import {
   Hospital,
   Siren,
 } from "lucide-react-native";
+import { tokens } from "@presentation/theme/design-tokens";
 
 export function EmergencySetupScreen() {
   const { t } = useTranslation();
@@ -149,7 +150,7 @@ export function EmergencySetupScreen() {
   if (isLoadingInfo) {
     return (
       <SafeAreaView className="flex-1 bg-light-bg dark:bg-background-primary items-center justify-center">
-        <ActivityIndicator size="large" color="#3B82F6" />
+        <ActivityIndicator size="large" color={tokens.colors.status.info} />
       </SafeAreaView>
     );
   }
@@ -166,7 +167,7 @@ export function EmergencySetupScreen() {
             onPress={() => router.back()}
             disabled={isSaving}
           >
-            <ChevronLeft size={24} color="#94A3B8" />
+            <ChevronLeft size={24} color={tokens.colors.text.secondary} />
           </Pressable>
           <Text className="text-lg font-bold text-light-text dark:text-text-primary">
             {t("emergencySetup.title")}
@@ -177,9 +178,12 @@ export function EmergencySetupScreen() {
             disabled={isSaving}
           >
             {isSaving ? (
-              <ActivityIndicator size="small" color="#3B82F6" />
+              <ActivityIndicator
+                size="small"
+                color={tokens.colors.status.info}
+              />
             ) : (
-              <Check size={20} color="#135BEC" />
+              <Check size={20} color={tokens.colors.primary.main} />
             )}
           </Pressable>
         </View>
@@ -192,7 +196,9 @@ export function EmergencySetupScreen() {
           <AlertBanner
             title={t("emergencySetup.criticalAccess")}
             message={t("emergencySetup.criticalAccessDesc")}
-            icon={<AlertTriangle size={20} color="#EF4444" />}
+            icon={
+              <AlertTriangle size={20} color={tokens.colors.status.error} />
+            }
             toggleLabel={t("emergencySetup.lockScreenVisible")}
             toggleEnabled={lockScreenVisible}
             onToggle={() => setLockScreenVisible(!lockScreenVisible)}
@@ -200,9 +206,9 @@ export function EmergencySetupScreen() {
 
           <View className="mb-6">
             <SectionHeader
-              icon={<Hospital size={18} color="#FFFFFF" />}
+              icon={<Hospital size={18} color={tokens.colors.text.primary} />}
               title={t("emergency.vitalInfo")}
-              iconBg="#3B82F6"
+              iconBg={tokens.colors.status.info}
             />
 
             <TextInputField
@@ -229,7 +235,7 @@ export function EmergencySetupScreen() {
               <TextInput
                 className="bg-light-bgSecondary dark:bg-background-secondary rounded-xl px-4 py-3 text-light-text dark:text-text-primary min-h-[80px]"
                 placeholder={t("emergencySetup.allergiesPlaceholder")}
-                placeholderTextColor="#64748B"
+                placeholderTextColor={tokens.colors.text.tertiary}
                 multiline
                 textAlignVertical="top"
                 value={allergies}
@@ -244,7 +250,7 @@ export function EmergencySetupScreen() {
               <TextInput
                 className="bg-light-bgSecondary dark:bg-background-secondary rounded-xl px-4 py-3 text-light-text dark:text-text-primary min-h-[80px]"
                 placeholder={t("emergencySetup.healthConditionsPlaceholder")}
-                placeholderTextColor="#64748B"
+                placeholderTextColor={tokens.colors.text.tertiary}
                 multiline
                 textAlignVertical="top"
                 value={healthConditions}
@@ -272,7 +278,7 @@ export function EmergencySetupScreen() {
                   <TextInput
                     className="flex-1 bg-light-bgSecondary dark:bg-background-secondary rounded-xl px-4 py-3 text-light-text dark:text-text-primary"
                     placeholder={t("emergencySetup.medicationPlaceholder")}
-                    placeholderTextColor="#64748B"
+                    placeholderTextColor={tokens.colors.text.tertiary}
                     value={medication}
                     onChangeText={(text) => handleMedicationChange(index, text)}
                   />
@@ -281,7 +287,7 @@ export function EmergencySetupScreen() {
                       className="ml-2 w-10 h-10 items-center justify-center"
                       onPress={() => handleRemoveMedicationField(index)}
                     >
-                      <X size={20} color="#EF4444" />
+                      <X size={20} color={tokens.colors.status.error} />
                     </Pressable>
                   )}
                 </View>
@@ -291,9 +297,9 @@ export function EmergencySetupScreen() {
 
           <View className="mb-6">
             <SectionHeader
-              icon={<Siren size={18} color="#FFFFFF" />}
+              icon={<Siren size={18} color={tokens.colors.text.primary} />}
               title={t("emergencySetup.contacts")}
-              iconBg="#EF4444"
+              iconBg={tokens.colors.status.error}
             />
 
             {contacts.map((contact) => (
@@ -312,7 +318,11 @@ export function EmergencySetupScreen() {
               className="bg-light-bgSecondary dark:bg-background-secondary rounded-xl p-4 flex-row items-center justify-center border-2 border-dashed border-light-border dark:border-ui-border active:bg-light-bgTertiary dark:active:bg-background-tertiary"
               onPress={() => openAddContactSheet(contacts.length === 0)}
             >
-              <Users size={20} color="#94A3B8" className="mr-2" />
+              <Users
+                size={20}
+                color={tokens.colors.text.secondary}
+                className="mr-2"
+              />
               <Text className="text-sm font-medium text-light-textSecondary dark:text-text-secondary">
                 {contacts.length === 0
                   ? t("emergencySetup.addContact")
@@ -333,7 +343,10 @@ export function EmergencySetupScreen() {
             onPress={handleSave}
           >
             {isSaving ? (
-              <ActivityIndicator size="small" color="#FFFFFF" />
+              <ActivityIndicator
+                size="small"
+                color={tokens.colors.text.primary}
+              />
             ) : (
               <Text
                 className={`text-base font-bold ${

--- a/src/presentation/screens/guest-mode-screen.tsx
+++ b/src/presentation/screens/guest-mode-screen.tsx
@@ -11,6 +11,7 @@ import { getDocumentIcon } from "@presentation/utils/document-display";
 import { useDocumentsStore } from "@stores/documents.store";
 import { useTranslation } from "react-i18next";
 import { ClipboardList } from "lucide-react-native";
+import { tokens } from "@presentation/theme/design-tokens";
 
 const AUTO_LOCK_TIMEOUT_KEY = "auto_lock_timeout_minutes";
 const storage = new SecureStorageAdapter(
@@ -160,7 +161,7 @@ export function GuestModeScreen() {
                   </View>
                 </View>
                 <View className="w-8 h-8 bg-primary-main/10 rounded-lg items-center justify-center ml-2">
-                  <ClipboardList size={20} color="#135BEC" />
+                  <ClipboardList size={20} color={tokens.colors.primary.main} />
                 </View>
               </View>
             </Pressable>

--- a/src/presentation/screens/pin-setup-screen.tsx
+++ b/src/presentation/screens/pin-setup-screen.tsx
@@ -11,6 +11,7 @@ import { SavePinUseCase } from "@domain/use-cases/save-pin.use-case";
 import { SecureStorageAdapter } from "@infrastructure/storage/secure-storage.adapter";
 import { useTranslation } from "react-i18next";
 import { Lock } from "lucide-react-native";
+import { tokens } from "@presentation/theme/design-tokens";
 
 const BIOMETRY_ENABLED_KEY = "biometry_enabled";
 const settingsStorage = new SecureStorageAdapter(
@@ -82,7 +83,7 @@ export function PinSetupScreen() {
               <View className="w-[100px] h-[100px] md:w-[120px] md:h-[120px] rounded-full bg-primary-main/10 justify-center items-center">
                 <View className="w-[70px] h-[70px] md:w-[85px] md:h-[85px] rounded-full bg-primary-main/20 justify-center items-center">
                   <View className="w-[45px] h-[45px] md:w-[55px] md:h-[55px] rounded-full bg-primary-main justify-center items-center">
-                    <Lock size={28} color="#FFFFFF" />
+                    <Lock size={28} color={tokens.colors.text.primary} />
                   </View>
                 </View>
               </View>

--- a/src/presentation/screens/profile-setup-screen.tsx
+++ b/src/presentation/screens/profile-setup-screen.tsx
@@ -13,6 +13,7 @@ import { useUserProfile } from "@presentation/hooks/use-user-profile";
 import { useProfilePhoto } from "@presentation/hooks/use-profile-photo";
 import { UserAvatar } from "@presentation/components/user-avatar";
 import { useTranslation } from "react-i18next";
+import { tokens } from "@presentation/theme/design-tokens";
 
 export function ProfileSetupScreen() {
   const { t } = useTranslation();
@@ -110,7 +111,7 @@ export function ProfileSetupScreen() {
           <TextInput
             className="bg-light-bgSecondary dark:bg-background-secondary rounded-xl px-4 py-4 text-light-text dark:text-text-primary text-base"
             placeholder={t("profile.namePlaceholder")}
-            placeholderTextColor="#9CA3AF"
+            placeholderTextColor={tokens.colors.text.secondary}
             value={name}
             onChangeText={setName}
             autoFocus={!profile?.name}
@@ -124,7 +125,7 @@ export function ProfileSetupScreen() {
           disabled={isSaving || isPhotoLoading}
         >
           {isSaving ? (
-            <ActivityIndicator color="#FFFFFF" />
+            <ActivityIndicator color={tokens.colors.text.primary} />
           ) : (
             <Text className="text-white font-bold text-base">
               {profile ? t("profile.saveChanges") : t("common.continue")}

--- a/src/presentation/screens/select-documents-screen.tsx
+++ b/src/presentation/screens/select-documents-screen.tsx
@@ -11,6 +11,7 @@ import {
 import { useDocumentsStore } from "@stores/documents.store";
 import { useTranslation } from "react-i18next";
 import { X, FileText, Lock, ShieldCheck } from "lucide-react-native";
+import { tokens } from "@presentation/theme/design-tokens";
 
 export function SelectDocumentsScreen() {
   const { t } = useTranslation();
@@ -78,7 +79,7 @@ export function SelectDocumentsScreen() {
       <View className="flex-1">
         <View className="flex-row items-center justify-between px-6 py-4 border-b border-light-border dark:border-ui-border">
           <Pressable onPress={() => router.back()}>
-            <X size={24} color="#94A3B8" />
+            <X size={24} color={tokens.colors.text.secondary} />
           </Pressable>
           <Text className="text-lg md:text-xl font-bold text-light-text dark:text-text-primary">
             {t("selectDocuments.title")}
@@ -106,7 +107,11 @@ export function SelectDocumentsScreen() {
                 </Text>
               ) : documents.length === 0 ? (
                 <View className="items-center justify-center py-12">
-                  <FileText size={48} color="#94A3B8" className="mb-4" />
+                  <FileText
+                    size={48}
+                    color={tokens.colors.text.secondary}
+                    className="mb-4"
+                  />
                   <Text className="text-base md:text-lg text-light-textSecondary dark:text-text-secondary mb-6 text-center">
                     {t("selectDocuments.noDocuments")}
                   </Text>
@@ -130,7 +135,11 @@ export function SelectDocumentsScreen() {
 
             <View className="bg-primary-main/10 rounded-2xl p-4 md:p-5 mb-6 border border-primary-main/20">
               <View className="flex-row items-start">
-                <Lock size={24} color="#135BEC" className="mr-3" />
+                <Lock
+                  size={24}
+                  color={tokens.colors.primary.main}
+                  className="mr-3"
+                />
                 <View className="flex-1">
                   <Text className="text-sm md:text-base font-bold text-light-text dark:text-text-primary mb-2">
                     {t("selectDocuments.secureLockTitle")}
@@ -144,7 +153,11 @@ export function SelectDocumentsScreen() {
 
             <View className="bg-light-bgSecondary dark:bg-background-secondary rounded-2xl p-4 md:p-5 mb-6 flex-row items-center justify-between">
               <View className="flex-row items-center">
-                <ShieldCheck size={20} color="#135BEC" className="mr-2" />
+                <ShieldCheck
+                  size={20}
+                  color={tokens.colors.primary.main}
+                  className="mr-2"
+                />
                 <Text className="text-base md:text-lg font-semibold text-light-text dark:text-text-primary">
                   {t("selectDocuments.sharingCount")}{" "}
                   <Text className="text-primary-main">

--- a/src/presentation/screens/settings-screen.tsx
+++ b/src/presentation/screens/settings-screen.tsx
@@ -26,6 +26,7 @@ import {
   Trash2,
   LogOut,
 } from "lucide-react-native";
+import { tokens } from "@presentation/theme/design-tokens";
 
 const BIOMETRY_ENABLED_KEY = "biometry_enabled";
 const AUTO_LOCK_TIMEOUT_KEY = "auto_lock_timeout_minutes";
@@ -300,7 +301,7 @@ export function SettingsScreen() {
                   {t("profile.editProfile")}
                 </Text>
               </View>
-              <ChevronRight size={20} color="#94A3B8" />
+              <ChevronRight size={20} color={tokens.colors.text.secondary} />
             </Pressable>
           </SettingsSection>
 
@@ -309,7 +310,7 @@ export function SettingsScreen() {
             <SettingsItem
               label={t("settings.changePin")}
               onPress={handleChangePin}
-              icon={<KeyRound size={20} color="#94A3B8" />}
+              icon={<KeyRound size={20} color={tokens.colors.text.secondary} />}
               isFirst
             />
             <SettingsItem
@@ -318,7 +319,7 @@ export function SettingsScreen() {
                   ? `${getBiometryName()}`
                   : t("settings.biometricLock")
               }
-              icon={<Pointer size={20} color="#94A3B8" />}
+              icon={<Pointer size={20} color={tokens.colors.text.secondary} />}
               switchValue={biometricEnabled}
               onSwitchChange={handleBiometricToggle}
               disabled={!biometryAvailable}
@@ -326,7 +327,9 @@ export function SettingsScreen() {
             <SettingsItem
               label={t("settings.autoLockTimeout")}
               onPress={handleAutoLockTimeout}
-              icon={<Hourglass size={20} color="#94A3B8" />}
+              icon={
+                <Hourglass size={20} color={tokens.colors.text.secondary} />
+              }
               value={autoLockTimeout}
               isLast
             />
@@ -337,14 +340,14 @@ export function SettingsScreen() {
             <SettingsItem
               label={t("settings.language")}
               onPress={handleLanguageChange}
-              icon={<Globe size={20} color="#94A3B8" />}
+              icon={<Globe size={20} color={tokens.colors.text.secondary} />}
               value={currentLanguageName}
               isFirst
             />
             <SettingsItem
               label={t("settings.theme")}
               onPress={handleThemeChange}
-              icon={<Palette size={20} color="#94A3B8" />}
+              icon={<Palette size={20} color={tokens.colors.text.secondary} />}
               value={themeLabels[themeMode]}
               isLast
             />
@@ -356,18 +359,18 @@ export function SettingsScreen() {
               label={t("common.version")}
               value={APP_CONFIG.version}
               showChevron={false}
-              icon={<Info size={20} color="#94A3B8" />}
+              icon={<Info size={20} color={tokens.colors.text.secondary} />}
               isFirst
             />
             <SettingsItem
               label={t("settings.termsOfService")}
               onPress={handleTermsOfService}
-              icon={<FileText size={20} color="#94A3B8" />}
+              icon={<FileText size={20} color={tokens.colors.text.secondary} />}
             />
             <SettingsItem
               label={t("settings.privacyPolicy")}
               onPress={handlePrivacyPolicy}
-              icon={<Lock size={20} color="#94A3B8" />}
+              icon={<Lock size={20} color={tokens.colors.text.secondary} />}
               isLast
             />
           </SettingsSection>
@@ -377,7 +380,7 @@ export function SettingsScreen() {
             <SettingsItem
               label={t("settings.clearAllData")}
               onPress={handleClearData}
-              icon={<Trash2 size={20} color="#EF4444" />}
+              icon={<Trash2 size={20} color={tokens.colors.status.error} />}
               destructive
               showChevron={false}
               isFirst
@@ -385,7 +388,7 @@ export function SettingsScreen() {
             <SettingsItem
               label={t("settings.logOut")}
               onPress={handleLogout}
-              icon={<LogOut size={20} color="#EF4444" />}
+              icon={<LogOut size={20} color={tokens.colors.status.error} />}
               destructive
               showChevron={false}
               loading={isLoggingOut}

--- a/src/presentation/screens/unlock-wallet-screen.tsx
+++ b/src/presentation/screens/unlock-wallet-screen.tsx
@@ -10,6 +10,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useBiometry } from "@presentation/hooks/use-biometry";
 import { SecureStorageAdapter } from "@infrastructure/storage/secure-storage.adapter";
 import { useTranslation } from "react-i18next";
+import { tokens } from "@presentation/theme/design-tokens";
 
 const PIN_LENGTH = 6;
 const BIOMETRY_ENABLED_KEY = "biometry_enabled";
@@ -165,7 +166,10 @@ export function UnlockWalletScreen() {
 
             {isAuthenticating && (
               <View className="mt-2 mb-2 px-6 py-3">
-                <ActivityIndicator size="small" color="#3B82F6" />
+                <ActivityIndicator
+                  size="small"
+                  color={tokens.colors.status.info}
+                />
               </View>
             )}
 

--- a/src/presentation/screens/wallet-home-screen.tsx
+++ b/src/presentation/screens/wallet-home-screen.tsx
@@ -21,6 +21,7 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { FileText, ClipboardList } from "lucide-react-native";
+import { tokens } from "@presentation/theme/design-tokens";
 
 export function WalletHomeScreen() {
   const { t } = useTranslation();
@@ -95,7 +96,10 @@ export function WalletHomeScreen() {
                   {t("wallet.welcome")}
                 </Text>
                 {profileLoading ? (
-                  <ActivityIndicator size="small" color="#3B82F6" />
+                  <ActivityIndicator
+                    size="small"
+                    color={tokens.colors.status.info}
+                  />
                 ) : (
                   <Text className="text-lg md:text-xl font-bold text-light-text dark:text-text-primary">
                     {profile?.name || t("wallet.guest")}
@@ -170,14 +174,21 @@ export function WalletHomeScreen() {
             <View className="gap-3">
               {documentsLoading ? (
                 <View className="bg-light-bgSecondary dark:bg-background-secondary rounded-2xl p-6 items-center justify-center">
-                  <ActivityIndicator size="large" color="#3B82F6" />
+                  <ActivityIndicator
+                    size="large"
+                    color={tokens.colors.status.info}
+                  />
                   <Text className="text-light-textSecondary dark:text-text-secondary mt-3">
                     {t("wallet.loadingDocuments")}
                   </Text>
                 </View>
               ) : !documents || documents.length === 0 ? (
                 <View className="bg-light-bgSecondary dark:bg-background-secondary rounded-2xl p-6 items-center">
-                  <FileText size={36} color="#94A3B8" className="mb-3" />
+                  <FileText
+                    size={36}
+                    color={tokens.colors.text.secondary}
+                    className="mb-3"
+                  />
                   <Text className="text-light-textSecondary dark:text-text-secondary text-center">
                     {t("wallet.noDocuments")}
                   </Text>
@@ -229,7 +240,10 @@ export function WalletHomeScreen() {
                           </View>
                         </View>
                         <View className="w-8 h-8 bg-primary-main/10 rounded-lg items-center justify-center ml-2">
-                          <ClipboardList size={20} color="#135BEC" />
+                          <ClipboardList
+                            size={20}
+                            color={tokens.colors.primary.main}
+                          />
                         </View>
                       </View>
                     </Pressable>

--- a/src/presentation/theme/__tests__/design-tokens-sync.test.ts
+++ b/src/presentation/theme/__tests__/design-tokens-sync.test.ts
@@ -19,7 +19,9 @@ const tailwindExtended = tailwindConfig.theme.extend;
 describe("design-tokens sync with tailwind.config.js", () => {
   describe("colors", () => {
     it("primary colors match", () => {
-      expect(tailwindExtended.colors.primary).toEqual(tailwindTheme.colors.primary);
+      expect(tailwindExtended.colors.primary).toEqual(
+        tailwindTheme.colors.primary,
+      );
     });
 
     it("background colors match", () => {
@@ -33,7 +35,9 @@ describe("design-tokens sync with tailwind.config.js", () => {
     });
 
     it("surface colors match", () => {
-      expect(tailwindExtended.colors.surface).toEqual(tailwindTheme.colors.surface);
+      expect(tailwindExtended.colors.surface).toEqual(
+        tailwindTheme.colors.surface,
+      );
     });
 
     it("ui colors match", () => {
@@ -41,15 +45,21 @@ describe("design-tokens sync with tailwind.config.js", () => {
     });
 
     it("border colors match", () => {
-      expect(tailwindExtended.colors.border).toEqual(tailwindTheme.colors.border);
+      expect(tailwindExtended.colors.border).toEqual(
+        tailwindTheme.colors.border,
+      );
     });
 
     it("status colors match", () => {
-      expect(tailwindExtended.colors.status).toEqual(tailwindTheme.colors.status);
+      expect(tailwindExtended.colors.status).toEqual(
+        tailwindTheme.colors.status,
+      );
     });
 
     it("accent colors match", () => {
-      expect(tailwindExtended.colors.accent).toEqual(tailwindTheme.colors.accent);
+      expect(tailwindExtended.colors.accent).toEqual(
+        tailwindTheme.colors.accent,
+      );
     });
 
     it("light-mode colors match", () => {

--- a/src/presentation/theme/__tests__/design-tokens-sync.test.ts
+++ b/src/presentation/theme/__tests__/design-tokens-sync.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Drift protection for design tokens.
+ *
+ * design-tokens.ts is the source of truth for React code (typed, `as const`).
+ * tailwind.config.js holds the same values in the format NativeWind expects.
+ *
+ * These tests verify both files are in sync so a PR that changes one without
+ * the other fails CI. If you change a token value, update BOTH files and
+ * these tests will pass.
+ */
+
+import { tailwindTheme } from "../design-tokens";
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const tailwindConfig = require("../../../../tailwind.config.js");
+
+const tailwindExtended = tailwindConfig.theme.extend;
+
+describe("design-tokens sync with tailwind.config.js", () => {
+  describe("colors", () => {
+    it("primary colors match", () => {
+      expect(tailwindExtended.colors.primary).toEqual(tailwindTheme.colors.primary);
+    });
+
+    it("background colors match", () => {
+      expect(tailwindExtended.colors.background).toEqual(
+        tailwindTheme.colors.background,
+      );
+    });
+
+    it("text colors match", () => {
+      expect(tailwindExtended.colors.text).toEqual(tailwindTheme.colors.text);
+    });
+
+    it("surface colors match", () => {
+      expect(tailwindExtended.colors.surface).toEqual(tailwindTheme.colors.surface);
+    });
+
+    it("ui colors match", () => {
+      expect(tailwindExtended.colors.ui).toEqual(tailwindTheme.colors.ui);
+    });
+
+    it("border colors match", () => {
+      expect(tailwindExtended.colors.border).toEqual(tailwindTheme.colors.border);
+    });
+
+    it("status colors match", () => {
+      expect(tailwindExtended.colors.status).toEqual(tailwindTheme.colors.status);
+    });
+
+    it("accent colors match", () => {
+      expect(tailwindExtended.colors.accent).toEqual(tailwindTheme.colors.accent);
+    });
+
+    it("light-mode colors match", () => {
+      expect(tailwindExtended.colors.light).toEqual(tailwindTheme.colors.light);
+    });
+  });
+
+  describe("spacing, radius, typography", () => {
+    it("spacing matches", () => {
+      expect(tailwindExtended.spacing).toEqual(tailwindTheme.spacing);
+    });
+
+    it("borderRadius matches", () => {
+      expect(tailwindExtended.borderRadius).toEqual(tailwindTheme.borderRadius);
+    });
+
+    it("fontSize matches", () => {
+      expect(tailwindExtended.fontSize).toEqual(tailwindTheme.fontSize);
+    });
+  });
+});

--- a/src/presentation/theme/colors.ts
+++ b/src/presentation/theme/colors.ts
@@ -1,41 +1,38 @@
 /**
- * Below are the colors that are used in the app. The colors are defined in the light and dark mode.
- * There are many other ways to style your app. For example, [Nativewind](https://www.nativewind.dev/), [Tamagui](https://tamagui.dev/), [unistyles](https://reactnativeunistyles.vercel.app), etc.
+ * Legacy shim — re-exports from design-tokens.ts in the shape expected by
+ * the Expo-template helpers (`useThemeColor`, `ThemedText`, `ThemedView`,
+ * `Collapsible`). New code should import `tokens` from design-tokens.ts
+ * directly instead of using `Colors`.
  */
 
 import { Platform } from "react-native";
 
-const tintColorLight = "#0a7ea4";
-const tintColorDark = "#fff";
+import { tokens, lightTokens } from "@presentation/theme/design-tokens";
 
 export const Colors = {
   light: {
-    text: "#11181C",
-    background: "#fff",
-    tint: tintColorLight,
-    icon: "#687076",
-    tabIconDefault: "#687076",
-    tabIconSelected: tintColorLight,
+    text: lightTokens.colors.text.primary,
+    background: lightTokens.colors.background.primary,
+    tint: tokens.colors.primary.main,
+    icon: lightTokens.colors.text.secondary,
+    tabIconDefault: lightTokens.colors.text.secondary,
+    tabIconSelected: tokens.colors.primary.main,
   },
   dark: {
-    text: "#ECEDEE",
-    background: "#151718",
-    tint: tintColorDark,
-    icon: "#9BA1A6",
-    tabIconDefault: "#9BA1A6",
-    tabIconSelected: tintColorDark,
+    text: tokens.colors.text.primary,
+    background: tokens.colors.background.primary,
+    tint: tokens.colors.primary.main,
+    icon: tokens.colors.text.secondary,
+    tabIconDefault: tokens.colors.text.secondary,
+    tabIconSelected: tokens.colors.primary.main,
   },
 };
 
 export const Fonts = Platform.select({
   ios: {
-    /** iOS `UIFontDescriptorSystemDesignDefault` */
     sans: "system-ui",
-    /** iOS `UIFontDescriptorSystemDesignSerif` */
     serif: "ui-serif",
-    /** iOS `UIFontDescriptorSystemDesignRounded` */
     rounded: "ui-rounded",
-    /** iOS `UIFontDescriptorSystemDesignMonospaced` */
     mono: "ui-monospace",
   },
   default: {

--- a/src/presentation/theme/design-tokens.ts
+++ b/src/presentation/theme/design-tokens.ts
@@ -1,128 +1,288 @@
 /**
- * Design System Tokens
- * Based on Stitch "thorix app" design
+ * Design System Tokens — single source of truth.
+ *
+ * This file is consumed by both TypeScript code (via `tokens` import)
+ * and by tailwind.config.js (via require). Values here MUST match what
+ * ends up in NativeWind classes.
+ *
+ * Usage in TSX (for `color=` props that can't use className):
+ *   import { tokens } from "@presentation/theme/design-tokens";
+ *   <ChevronLeft size={24} color={tokens.colors.text.secondary} />
+ *
+ * Usage in className (NativeWind):
+ *   <View className="bg-background-primary text-text-primary" />
  */
 
-export const DesignTokens = {
-  colors: {
-    // Primary colors
-    primary: {
-      main: "#135BEC",
-      light: "#4A7FEF",
-      dark: "#0D42B0",
-    },
-    // Background colors
-    background: {
-      primary: "#0A1929",
-      secondary: "#132F4C",
-      tertiary: "#1A2F45",
-    },
-    // Text colors
-    text: {
-      primary: "#FFFFFF",
-      secondary: "#B2BAC2",
-      tertiary: "#8B95A0",
-    },
-    // Status colors
-    status: {
-      success: "#4CAF50",
-      error: "#F44336",
-      warning: "#FF9800",
-      info: "#2196F3",
-    },
-    // UI colors
-    ui: {
-      border: "#1E3A52",
-      divider: "#1A2F45",
-      overlay: "rgba(10, 25, 41, 0.8)",
-    },
-  },
+// ============================================================================
+// Colors — dark mode (primary theme)
+// ============================================================================
 
-  spacing: {
-    xs: 4,
-    sm: 8,
-    md: 16,
-    lg: 24,
-    xl: 32,
-    xxl: 48,
-    xxxl: 64,
+const darkColors = {
+  primary: {
+    main: "#135BEC",
+    light: "#4A7EF0",
+    dark: "#0D47B8",
   },
-
-  borderRadius: {
-    sm: 4,
-    md: 8,
-    lg: 12,
-    xl: 16,
-    xxl: 24,
-    full: 9999,
+  background: {
+    primary: "#0A1628",
+    secondary: "#0F1F38",
+    tertiary: "#152840",
   },
-
-  typography: {
-    fontFamily: {
-      regular: "System",
-      medium: "System",
-      semiBold: "System",
-      bold: "System",
-    },
-    fontSize: {
-      xs: 12,
-      sm: 14,
-      md: 16,
-      lg: 18,
-      xl: 20,
-      xxl: 24,
-      xxxl: 32,
-      display: 40,
-    },
-    lineHeight: {
-      tight: 1.2,
-      normal: 1.5,
-      relaxed: 1.75,
-    },
-    fontWeight: {
-      regular: "400" as const,
-      medium: "500" as const,
-      semiBold: "600" as const,
-      bold: "700" as const,
-    },
+  text: {
+    primary: "#FFFFFF",
+    secondary: "#94A3B8",
+    tertiary: "#64748B",
   },
-
-  shadows: {
-    sm: {
-      shadowColor: "#000",
-      shadowOffset: { width: 0, height: 2 },
-      shadowOpacity: 0.1,
-      shadowRadius: 4,
-      elevation: 2,
-    },
-    md: {
-      shadowColor: "#000",
-      shadowOffset: { width: 0, height: 4 },
-      shadowOpacity: 0.15,
-      shadowRadius: 8,
-      elevation: 4,
-    },
-    lg: {
-      shadowColor: "#000",
-      shadowOffset: { width: 0, height: 8 },
-      shadowOpacity: 0.2,
-      shadowRadius: 16,
-      elevation: 8,
-    },
+  surface: {
+    card: "#1A2942",
+    hover: "#243352",
   },
-
-  animation: {
-    duration: {
-      fast: 150,
-      normal: 300,
-      slow: 500,
-    },
-    easing: {
-      easeIn: "ease-in",
-      easeOut: "ease-out",
-      easeInOut: "ease-in-out",
-    },
+  ui: {
+    border: "#1E293B",
+    divider: "#334155",
+    overlay: "rgba(0, 0, 0, 0.5)",
+  },
+  border: {
+    primary: "#1E293B",
+    subtle: "#1E293B",
   },
 } as const;
 
-export type DesignTokensType = typeof DesignTokens;
+// ============================================================================
+// Colors — light mode
+// ============================================================================
+
+const lightColors = {
+  primary: {
+    main: "#135BEC",
+    light: "#4A7EF0",
+    dark: "#0D47B8",
+  },
+  background: {
+    primary: "#FFFFFF",
+    secondary: "#F1F5F9",
+    tertiary: "#E2E8F0",
+  },
+  text: {
+    primary: "#0F172A",
+    secondary: "#64748B",
+    tertiary: "#94A3B8",
+  },
+  surface: {
+    card: "#FFFFFF",
+    hover: "#F1F5F9",
+  },
+  ui: {
+    border: "#E2E8F0",
+    divider: "#CBD5E1",
+    overlay: "rgba(15, 23, 42, 0.5)",
+  },
+  border: {
+    primary: "#E2E8F0",
+    subtle: "#E2E8F0",
+  },
+} as const;
+
+// ============================================================================
+// Colors — shared (status, accent) — same in both modes
+// ============================================================================
+
+const statusColors = {
+  success: "#10B981",
+  error: "#EF4444",
+  warning: "#F59E0B",
+  info: "#3B82F6",
+} as const;
+
+const accentColors = {
+  orange: "#F97316",
+  green: "#22C55E",
+} as const;
+
+// ============================================================================
+// Spacing (in px, 4px base scale)
+// ============================================================================
+
+const spacing = {
+  xs: 4,
+  sm: 8,
+  md: 16,
+  lg: 24,
+  xl: 32,
+  xxl: 48,
+  xxxl: 64,
+} as const;
+
+// ============================================================================
+// Border radius
+// ============================================================================
+
+const borderRadius = {
+  sm: 4,
+  md: 8,
+  lg: 12,
+  xl: 16,
+  xxl: 24,
+  full: 9999,
+} as const;
+
+// ============================================================================
+// Typography
+// ============================================================================
+
+const typography = {
+  fontFamily: {
+    regular: "System",
+    medium: "System",
+    semiBold: "System",
+    bold: "System",
+  },
+  fontSize: {
+    xs: 12,
+    sm: 14,
+    md: 16,
+    lg: 18,
+    xl: 20,
+    xxl: 24,
+    xxxl: 32,
+    display: 40,
+  },
+  lineHeight: {
+    tight: 1.2,
+    normal: 1.5,
+    relaxed: 1.75,
+  },
+  fontWeight: {
+    regular: "400" as const,
+    medium: "500" as const,
+    semiBold: "600" as const,
+    bold: "700" as const,
+  },
+} as const;
+
+// ============================================================================
+// Shadows
+// ============================================================================
+
+const shadows = {
+  sm: {
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 2,
+  },
+  md: {
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.15,
+    shadowRadius: 8,
+    elevation: 4,
+  },
+  lg: {
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.2,
+    shadowRadius: 16,
+    elevation: 8,
+  },
+} as const;
+
+// ============================================================================
+// Animation
+// ============================================================================
+
+const animation = {
+  duration: {
+    fast: 150,
+    normal: 300,
+    slow: 500,
+  },
+  easing: {
+    easeIn: "ease-in",
+    easeOut: "ease-out",
+    easeInOut: "ease-in-out",
+  },
+} as const;
+
+// ============================================================================
+// Exported tokens object — primary shape used across the app
+// ============================================================================
+
+export const tokens = {
+  colors: {
+    ...darkColors,
+    status: statusColors,
+    accent: accentColors,
+  },
+  spacing,
+  borderRadius,
+  typography,
+  shadows,
+  animation,
+} as const;
+
+// Light mode variants — exposed separately for components that need both
+export const lightTokens = {
+  colors: {
+    ...lightColors,
+    status: statusColors,
+    accent: accentColors,
+  },
+} as const;
+
+// ============================================================================
+// Tailwind-compatible export — consumed by tailwind.config.js
+// ============================================================================
+
+/**
+ * Exported in a shape that tailwind.config.js can spread into `theme.extend`.
+ * Dark colors live at the root (default), light colors under the `light`
+ * namespace, matching the original tailwind config.
+ */
+export const tailwindTheme = {
+  colors: {
+    primary: darkColors.primary,
+    background: darkColors.background,
+    text: darkColors.text,
+    surface: darkColors.surface,
+    ui: darkColors.ui,
+    border: darkColors.border,
+    status: statusColors,
+    accent: accentColors,
+    light: {
+      bg: lightColors.background.primary,
+      bgSecondary: lightColors.background.secondary,
+      bgTertiary: lightColors.background.tertiary,
+      text: lightColors.text.primary,
+      textSecondary: lightColors.text.secondary,
+      textTertiary: lightColors.text.tertiary,
+      card: lightColors.surface.card,
+      border: lightColors.ui.border,
+      divider: lightColors.ui.divider,
+    },
+  },
+  spacing: Object.fromEntries(
+    Object.entries(spacing).map(([k, v]) => [k, `${v}px`]),
+  ),
+  borderRadius: Object.fromEntries(
+    Object.entries(borderRadius).map(([k, v]) =>
+      k === "full" ? [k, "9999px"] : [k, `${v}px`],
+    ),
+  ),
+  fontSize: Object.fromEntries(
+    Object.entries(typography.fontSize)
+      .filter(([k]) => k !== "display")
+      .map(([k, v]) => [k, `${v}px`]),
+  ),
+} as const;
+
+// ============================================================================
+// Legacy aliases — DO NOT USE in new code. Kept for gradual migration.
+// ============================================================================
+
+/** @deprecated Use `tokens` instead */
+export const DesignTokens = tokens;
+
+export type TokensType = typeof tokens;
+export type LightTokensType = typeof lightTokens;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,15 @@
-/** @type {import('tailwindcss').Config} */
+/**
+ * Tailwind / NativeWind theme configuration.
+ *
+ * IMPORTANT: Colors, spacing, borderRadius, and fontSize MUST match
+ * src/presentation/theme/design-tokens.ts exactly. A sync test
+ * (src/presentation/theme/__tests__/design-tokens-sync.test.ts)
+ * verifies this on every CI run — drift is blocked at PR time.
+ *
+ * When you change a value here, also change it in design-tokens.ts.
+ *
+ * @type {import('tailwindcss').Config}
+ */
 module.exports = {
   content: ["./app/**/*.{js,jsx,ts,tsx}", "./src/**/*.{js,jsx,ts,tsx}"],
   presets: [require("nativewind/preset")],
@@ -11,7 +22,6 @@ module.exports = {
           light: "#4A7EF0",
           dark: "#0D47B8",
         },
-        // Dark mode colors (original)
         background: {
           primary: "#0A1628",
           secondary: "#0F1F38",
@@ -31,17 +41,9 @@ module.exports = {
           divider: "#334155",
           overlay: "rgba(0, 0, 0, 0.5)",
         },
-        // Light mode colors
-        light: {
-          bg: "#FFFFFF",
-          bgSecondary: "#F1F5F9",
-          bgTertiary: "#E2E8F0",
-          text: "#0F172A",
-          textSecondary: "#64748B",
-          textTertiary: "#94A3B8",
-          card: "#FFFFFF",
-          border: "#E2E8F0",
-          divider: "#CBD5E1",
+        border: {
+          primary: "#1E293B",
+          subtle: "#1E293B",
         },
         status: {
           success: "#10B981",
@@ -53,9 +55,16 @@ module.exports = {
           orange: "#F97316",
           green: "#22C55E",
         },
-        border: {
-          primary: "#1E293B",
-          subtle: "#1E293B",
+        light: {
+          bg: "#FFFFFF",
+          bgSecondary: "#F1F5F9",
+          bgTertiary: "#E2E8F0",
+          text: "#0F172A",
+          textSecondary: "#64748B",
+          textTertiary: "#94A3B8",
+          card: "#FFFFFF",
+          border: "#E2E8F0",
+          divider: "#CBD5E1",
         },
       },
       spacing: {


### PR DESCRIPTION
## Summary

Consolidates the design token system into a single source of truth, eliminates 135 hardcoded hex values across 30 component and screen files, and adds automatic drift protection via a sync test that runs in CI.

## Motivation

The project had three parallel sources of token values (tailwind.config.js, design-tokens.ts, and a legacy Expo colors.ts) that had drifted apart. At the same time, components used hardcoded hex literals for props that cannot accept className (icon color, placeholderTextColor, ActivityIndicator color, Switch track/thumb colors), so changing a theme color required editing dozens of files and was error-prone.

With the product heading to the App Store, this refactor gives a clean base for post-launch maintenance and prepares the ground for future token-level changes (rebrand, new variants, accessibility tweaks) without regressions.

## Changes

### Commit 1 — refactor(theme): consolidate design tokens and add drift protection

- Rewrites design-tokens.ts with primary dark palette, a light-mode counterpart, shared status and accent groups, spacing, radius, typography, shadows, and animation tokens
- Exports a tailwindTheme shape ready to be spread into NativeWind config
- Updates tailwind.config.js with a clear header warning that values MUST match design-tokens.ts
- Adds a sync test at src/presentation/theme/__tests__/design-tokens-sync.test.ts that fails CI if the two files drift
- Converts the legacy colors.ts into a thin shim that re-exports from the new tokens so the Expo-template helpers (useThemeColor, ThemedText, ThemedView, Collapsible) use Thoryx brand values instead of scaffold defaults

### Commit 2 — refactor(ui): replace hardcoded hex values with design tokens

- Replaces 135 hardcoded hex values across 30 files with imports from design-tokens
- Adds import { tokens } to each touched file
- Uses semantic names (tokens.colors.text.secondary, tokens.colors.status.error, tokens.colors.primary.main) everywhere
- Leaves decorative colors in fake-credit-card.tsx and SVG path data in svg-icon.tsx intentionally as literals

## Files changed

- Theme: design-tokens.ts, colors.ts, tailwind.config.js, new sync test
- 13 screens: add-credit-card, add-document, document-details, documents, emergency-details, emergency-setup, guest-mode, pin-setup, profile-setup, select-documents, settings, unlock-wallet, wallet-home
- 17 components: add-contact-bottom-sheet, camera-scanner, checkbox-option, contact-card, credit-card-preview, date-input, dropdown-input, info-banner, photo-upload, pin-auth-bottom-sheet, search-bar, section-header, selectable-document-item, settings-item, text-input-field, themed-text, user-avatar

Total: 33 files modified, 1 file added.

## Verification

- `npx tsc --noEmit` — 0 new errors (only pre-existing use-countdown.ts error from develop)
- `npm run lint` — 0 errors (322 warnings, all pre-existing)
- `npm test` — 761 passed (12 new tests from the sync suite, was 749)

## Not done in this PR

- Dark/light mode toggle was already implemented in develop, no changes needed
- Expo-template leftover components (ThemedText, ThemedView, ParallaxScrollView, Collapsible, modal.tsx) are kept alive via the colors.ts shim, not removed in this PR to keep blast radius small

## Test plan

- [x] Type check passes
- [x] Lint passes with 0 errors
- [x] All existing tests pass
- [x] New sync tests pass (12 new tests)
- [x] Smoke test on simulator: launch app, navigate through main screens, verify no visual regressions
- [x] Verify dark mode still toggles correctly