### PR TITLE
fix(ux): non-blocking PBKDF2 + loading state on PIN screens

### DIFF
--- a/src/infrastructure/security/pbkdf2.service.ts
+++ b/src/infrastructure/security/pbkdf2.service.ts
@@ -38,6 +38,9 @@ export class Pbkdf2Service {
     const derived = await pbkdf2Async(sha256, pin, salt, {
       c: iterations,
       dkLen: KEY_BYTES,
+      // Yield to the JS event loop every 10ms so UI re-renders and touch
+      // events stay responsive during the ~1-2s key derivation.
+      asyncTick: 10,
     });
     return toHex(derived);
   }

--- a/src/presentation/screens/change-pin-screen.tsx
+++ b/src/presentation/screens/change-pin-screen.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
-import { View, Text, Pressable, Alert } from "react-native";
+import { ActivityIndicator, Alert, Text, View } from "react-native";
+import { tokens } from "@presentation/theme/design-tokens";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { NumericKeypad } from "@presentation/components/numeric-keypad";
@@ -26,10 +27,17 @@ export function ChangePinScreen() {
   const [currentPin, setCurrentPin] = useState("");
   const [newPin, setNewPin] = useState("");
   const [error, setError] = useState(false);
+  const [isVerifying, setIsVerifying] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
   const [showConfirmation, setShowConfirmation] = useState(false);
+  const isBusy = isVerifying || isSaving;
 
   useEffect(() => {
-    if (step === "current" && currentPin.length === PIN_LENGTH) {
+    if (
+      step === "current" &&
+      currentPin.length === PIN_LENGTH &&
+      !isVerifying
+    ) {
       handleVerifyCurrentPin();
     }
   }, [currentPin]);
@@ -41,6 +49,7 @@ export function ChangePinScreen() {
   }, [newPin]);
 
   const handleKeyPress = (value: string) => {
+    if (isBusy) return;
     if (step === "current") {
       if (currentPin.length < PIN_LENGTH) {
         setCurrentPin(currentPin + value);
@@ -54,6 +63,7 @@ export function ChangePinScreen() {
   };
 
   const handleBackspace = () => {
+    if (isBusy) return;
     if (step === "current") {
       setCurrentPin(currentPin.slice(0, -1));
       setError(false);
@@ -67,6 +77,7 @@ export function ChangePinScreen() {
       return;
     }
 
+    setIsVerifying(true);
     try {
       const verifyPinUseCase = new VerifyPinWithLockoutUseCase(
         new PinRepositoryImpl(),
@@ -91,31 +102,37 @@ export function ChangePinScreen() {
         setCurrentPin("");
         setError(false);
       }, 1000);
+    } finally {
+      setIsVerifying(false);
     }
   };
 
   const handleConfirmNewPin = async (confirmedPin: string) => {
-    if (newPin === confirmedPin) {
-      try {
-        const repository = new PinRepositoryImpl();
-        const savePinUseCase = new SavePinUseCase(repository);
+    if (newPin !== confirmedPin) {
+      return;
+    }
+    setIsSaving(true);
+    try {
+      const repository = new PinRepositoryImpl();
+      const savePinUseCase = new SavePinUseCase(repository);
 
-        const result = await savePinUseCase.execute({ pin: newPin });
+      const result = await savePinUseCase.execute({ pin: newPin });
 
-        if (result.success) {
-          setShowConfirmation(false);
-          Alert.alert(t("common.success"), t("auth.changePinSuccess"), [
-            {
-              text: t("common.ok"),
-              onPress: () => router.back(),
-            },
-          ]);
-        } else {
-          Alert.alert(t("common.error"), result.message || t("common.error"));
-        }
-      } catch {
-        Alert.alert(t("common.error"), t("common.error"));
+      if (result.success) {
+        setShowConfirmation(false);
+        Alert.alert(t("common.success"), t("auth.changePinSuccess"), [
+          {
+            text: t("common.ok"),
+            onPress: () => router.back(),
+          },
+        ]);
+      } else {
+        Alert.alert(t("common.error"), result.message || t("common.error"));
       }
+    } catch {
+      Alert.alert(t("common.error"), t("common.error"));
+    } finally {
+      setIsSaving(false);
     }
   };
 
@@ -174,8 +191,19 @@ export function ChangePinScreen() {
             </Text>
           </View>
 
-          {/* Error Message */}
-          {error && (
+          {isBusy && (
+            <View className="flex-row items-center justify-center mb-4 gap-2">
+              <ActivityIndicator
+                size="small"
+                color={tokens.colors.primary.main}
+              />
+              <Text className="text-sm font-semibold text-primary-main">
+                {isSaving ? t("auth.saving") : t("auth.verifying")}
+              </Text>
+            </View>
+          )}
+
+          {!isBusy && error && (
             <View className="items-center mb-4">
               <View className="flex-row items-center">
                 <Text className="text-sm font-semibold text-status-error">

--- a/src/presentation/screens/pin-setup-screen.tsx
+++ b/src/presentation/screens/pin-setup-screen.tsx
@@ -3,7 +3,7 @@ import { PinDot } from "@presentation/components/pin-dot";
 import { ToggleOption } from "@presentation/components/toggle-option";
 import { PinConfirmationBottomSheet } from "@presentation/components/pin-confirmation-bottom-sheet";
 import { useState } from "react";
-import { Pressable, Text, View } from "react-native";
+import { ActivityIndicator, Pressable, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { PinRepositoryImpl } from "@data/repositories/pin.repository.impl";
@@ -26,48 +26,55 @@ export function PinSetupScreen() {
   const [pin, setPin] = useState("");
   const [biometricEnabled, setBiometricEnabled] = useState(false);
   const [showConfirmation, setShowConfirmation] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
   const router = useRouter();
 
   const handleKeyPress = (value: string) => {
+    if (isSaving) return;
     if (pin.length < PIN_LENGTH) {
       setPin(pin + value);
     }
   };
 
   const handleBackspace = () => {
+    if (isSaving) return;
     setPin(pin.slice(0, -1));
   };
 
   const handleToggleBiometric = () => {
+    if (isSaving) return;
     setBiometricEnabled(!biometricEnabled);
   };
 
   const handleConfirm = () => {
-    if (pin.length === PIN_LENGTH) {
+    if (pin.length === PIN_LENGTH && !isSaving) {
       setShowConfirmation(true);
     }
   };
 
   const handleFinishSetup = async (confirmedPin: string) => {
-    if (pin === confirmedPin) {
-      try {
-        const repository = new PinRepositoryImpl();
-        const savePinUseCase = new SavePinUseCase(repository);
+    if (pin !== confirmedPin) {
+      return;
+    }
+    setIsSaving(true);
+    try {
+      const repository = new PinRepositoryImpl();
+      const savePinUseCase = new SavePinUseCase(repository);
 
-        const result = await savePinUseCase.execute({ pin });
+      const result = await savePinUseCase.execute({ pin });
 
-        if (result.success) {
-          // Save biometric preference
-          await settingsStorage.set(
-            BIOMETRY_ENABLED_KEY,
-            biometricEnabled ? "true" : "false",
-          );
-          setShowConfirmation(false);
-          router.push("/(tabs)");
-        }
-      } catch (error) {
-        console.error("Error saving PIN:", error);
+      if (result.success) {
+        await settingsStorage.set(
+          BIOMETRY_ENABLED_KEY,
+          biometricEnabled ? "true" : "false",
+        );
+        setShowConfirmation(false);
+        router.push("/(tabs)");
       }
+    } catch (error) {
+      console.error("Error saving PIN:", error);
+    } finally {
+      setIsSaving(false);
     }
   };
 
@@ -164,6 +171,23 @@ export function PinSetupScreen() {
         onConfirm={handleFinishSetup}
         originalPin={pin}
       />
+
+      {isSaving && (
+        <View
+          accessibilityRole="progressbar"
+          className="absolute inset-0 items-center justify-center bg-black/60"
+        >
+          <View className="items-center gap-3 rounded-2xl bg-background-primary px-8 py-6">
+            <ActivityIndicator
+              size="large"
+              color={tokens.colors.primary.main}
+            />
+            <Text className="text-base font-semibold text-text-primary">
+              {t("auth.saving")}
+            </Text>
+          </View>
+        </View>
+      )}
     </SafeAreaView>
   );
 }

--- a/src/presentation/screens/unlock-wallet-screen.tsx
+++ b/src/presentation/screens/unlock-wallet-screen.tsx
@@ -38,6 +38,7 @@ export function UnlockWalletScreen() {
   const [pin, setPin] = useState("");
   const [error, setError] = useState(false);
   const [isAuthenticating, setIsAuthenticating] = useState(false);
+  const [isVerifyingPin, setIsVerifyingPin] = useState(false);
   const [biometryEnabled, setBiometryEnabled] = useState(false);
   const [lockedUntil, setLockedUntil] = useState<number | null>(null);
   const [attemptCount, setAttemptCount] = useState(0);
@@ -85,6 +86,7 @@ export function UnlockWalletScreen() {
 
   const verifyPin = useCallback(
     async (value: string) => {
+      setIsVerifyingPin(true);
       try {
         const useCase = new VerifyPinWithLockoutUseCase(
           pinRepository,
@@ -109,16 +111,18 @@ export function UnlockWalletScreen() {
           setPin("");
           setError(false);
         }, 1000);
+      } finally {
+        setIsVerifyingPin(false);
       }
     },
     [pinRepository, attemptsRepository, router],
   );
 
   useEffect(() => {
-    if (pin.length === PIN_LENGTH && !isLocked) {
+    if (pin.length === PIN_LENGTH && !isLocked && !isVerifyingPin) {
       verifyPin(pin);
     }
-  }, [pin, isLocked, verifyPin]);
+  }, [pin, isLocked, isVerifyingPin, verifyPin]);
 
   const handleBiometricAuth = async () => {
     if (isLocked) {
@@ -142,7 +146,7 @@ export function UnlockWalletScreen() {
   };
 
   const handleKeyPress = (value: string) => {
-    if (isLocked) return;
+    if (isLocked || isVerifyingPin) return;
     if (pin.length < PIN_LENGTH) {
       setPin(pin + value);
       setError(false);
@@ -150,7 +154,7 @@ export function UnlockWalletScreen() {
   };
 
   const handleBackspace = () => {
-    if (isLocked) return;
+    if (isLocked || isVerifyingPin) return;
     setPin(pin.slice(0, -1));
     setError(false);
   };
@@ -233,7 +237,22 @@ export function UnlockWalletScreen() {
               </View>
             )}
 
-            {!isLocked && error && (
+            {!isLocked && isVerifyingPin && (
+              <View
+                accessibilityRole="progressbar"
+                className="flex-row items-center mt-2 mb-2 gap-2"
+              >
+                <ActivityIndicator
+                  size="small"
+                  color={tokens.colors.primary.main}
+                />
+                <Text className="text-sm font-semibold text-primary-main">
+                  {t("auth.verifying")}
+                </Text>
+              </View>
+            )}
+
+            {!isLocked && !isVerifyingPin && error && (
               <View className="items-center mt-2 mb-2">
                 <Text className="text-sm font-semibold text-status-error">
                   {t("auth.wrongPin")}

--- a/src/shared/i18n/locales/en-US.json
+++ b/src/shared/i18n/locales/en-US.json
@@ -178,6 +178,8 @@
     "changePinSuccess": "PIN changed successfully",
     "emergencyDetails": "Emergency Details",
     "unlockWallet": "Unlock Wallet",
+    "verifying": "Verifying...",
+    "saving": "Saving...",
     "lockedTitle": "Too many attempts",
     "lockedMessage": "Try again in {{time}}",
     "attemptsRemaining": "{{count}} attempt remaining before lockout",

--- a/src/shared/i18n/locales/pt-BR.json
+++ b/src/shared/i18n/locales/pt-BR.json
@@ -178,6 +178,8 @@
     "changePinSuccess": "PIN alterado com sucesso",
     "emergencyDetails": "Emergency Details",
     "unlockWallet": "Desbloquear Carteira",
+    "verifying": "Verificando...",
+    "saving": "Salvando...",
     "lockedTitle": "Muitas tentativas",
     "lockedMessage": "Tente novamente em {{time}}",
     "attemptsRemaining": "{{count}} tentativa restante antes do bloqueio",


### PR DESCRIPTION
## Summary

Usuário relatou que o app **trava ao digitar o PIN no unlock**. Duas causas, duas correções:

### 1. `pbkdf2Async` rodando sem yield configurado

210k iterações de PBKDF2-HMAC-SHA256 em JS puro leva ~1–2s em devices mid-range. O `pbkdf2Async` do `@noble/hashes` aceita `asyncTick` para yieldar o event loop entre chunks — estava usando o default implícito, o que dependia do comportamento interno.

Agora passa explícito `asyncTick: 10` → event loop respira a cada 10ms, re-renders e touch events ficam responsivos.

### 2. Zero feedback visual durante a derivação

O usuário digitava o 6º dígito, a JS thread ia para PBKDF2 por 1–2s, e a tela parecia travada. Adicionado estado `isVerifying` / `isSaving` nas três telas que disparam hash:

- **`unlock-wallet-screen`**: indicador inline "Verificando..." com spinner; teclado ignora inputs durante a verificação.
- **`change-pin-screen`**: indicador inline "Verificando..." / "Salvando..." no mesmo slot do erro; teclado ignora inputs.
- **`pin-setup-screen`**: overlay full-screen com "Salvando..." após confirmação; bloqueia interação até o save terminar.

Strings `auth.verifying` / `auth.saving` adicionadas em pt-BR e en-US.

## Test plan

- [x] `npm test` — 825 passando
- [x] `npx tsc --noEmit` sem novos erros
- [ ] QA manual iOS: digitar PIN no unlock → spinner aparece → desbloqueia sem travar
- [ ] QA manual iOS: pin-setup → confirmar → overlay "Salvando..." → navega pra home
- [ ] QA manual iOS: change-pin → confirmar PIN atual → feedback inline
- [ ] QA manual Android (device mid-range se possível): mesmo fluxo, sem freeze perceptível