### PR TITLE
feat(emergency): editable contacts + localized add-contact sheet

### DIFF
--- a/src/presentation/components/add-contact-bottom-sheet.test.tsx
+++ b/src/presentation/components/add-contact-bottom-sheet.test.tsx
@@ -34,7 +34,10 @@ describe("AddContactBottomSheet", () => {
     fireEvent.press(saveButton!);
     expect(onSave).not.toHaveBeenCalled();
 
-    fireEvent.changeText(getByPlaceholderText(/Digite o nome completo/i), "Ana");
+    fireEvent.changeText(
+      getByPlaceholderText(/Digite o nome completo/i),
+      "Ana",
+    );
     fireEvent.changeText(
       getByPlaceholderText(/Ex: Cônjuge, Pai, Irmã/i),
       "Mãe",
@@ -95,10 +98,7 @@ describe("AddContactBottomSheet", () => {
       isPrimary: false,
     };
     const { getByText } = render(
-      <AddContactBottomSheet
-        {...baseProps}
-        initialContact={initialContact}
-      />,
+      <AddContactBottomSheet {...baseProps} initialContact={initialContact} />,
     );
 
     expect(getByText(/Editar Contato/i)).toBeTruthy();

--- a/src/presentation/components/add-contact-bottom-sheet.test.tsx
+++ b/src/presentation/components/add-contact-bottom-sheet.test.tsx
@@ -26,12 +26,12 @@ describe("AddContactBottomSheet", () => {
 
   it("keeps the save button disabled until every field has a value", () => {
     const onSave = jest.fn();
-    const { getByPlaceholderText, getByText } = render(
+    const { getByPlaceholderText, getByLabelText } = render(
       <AddContactBottomSheet {...baseProps} onSave={onSave} />,
     );
 
-    const saveButton = getByText(/Salvar Contato/i).parent;
-    fireEvent.press(saveButton!);
+    const saveButton = getByLabelText(/Salvar Contato/i);
+    fireEvent.press(saveButton);
     expect(onSave).not.toHaveBeenCalled();
 
     fireEvent.changeText(
@@ -44,7 +44,7 @@ describe("AddContactBottomSheet", () => {
     );
     fireEvent.changeText(getByPlaceholderText(/\+55/), "11999999999");
 
-    fireEvent.press(saveButton!);
+    fireEvent.press(saveButton);
     expect(onSave).toHaveBeenCalledWith(
       expect.objectContaining({
         fullName: "Ana",
@@ -65,7 +65,7 @@ describe("AddContactBottomSheet", () => {
       isPrimary: true,
     };
 
-    const { getByDisplayValue, getByText } = render(
+    const { getByDisplayValue, getByLabelText } = render(
       <AddContactBottomSheet
         {...baseProps}
         initialContact={initialContact}
@@ -78,7 +78,7 @@ describe("AddContactBottomSheet", () => {
     expect(getByDisplayValue("11988887777")).toBeTruthy();
 
     fireEvent.changeText(getByDisplayValue("Marcos"), "Marcos Matsuda");
-    fireEvent.press(getByText(/Salvar Contato/i).parent!);
+    fireEvent.press(getByLabelText(/Salvar Contato/i));
 
     expect(onSave).toHaveBeenCalledWith({
       id: "contact_123",

--- a/src/presentation/components/add-contact-bottom-sheet.test.tsx
+++ b/src/presentation/components/add-contact-bottom-sheet.test.tsx
@@ -1,0 +1,114 @@
+import React from "react";
+import { fireEvent, render } from "@testing-library/react-native";
+import { AddContactBottomSheet } from "./add-contact-bottom-sheet";
+import { EmergencyContact } from "@domain/entities/emergency-info.entity";
+
+describe("AddContactBottomSheet", () => {
+  const baseProps = {
+    visible: true,
+    onClose: jest.fn(),
+    onSave: jest.fn(),
+    isPrimary: false,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders localized placeholders instead of hard-coded English", () => {
+    const { getByPlaceholderText } = render(
+      <AddContactBottomSheet {...baseProps} />,
+    );
+
+    expect(getByPlaceholderText(/Digite o nome completo/i)).toBeTruthy();
+    expect(getByPlaceholderText(/Ex: Cônjuge, Pai, Irmã/i)).toBeTruthy();
+  });
+
+  it("keeps the save button disabled until every field has a value", () => {
+    const onSave = jest.fn();
+    const { getByPlaceholderText, getByText } = render(
+      <AddContactBottomSheet {...baseProps} onSave={onSave} />,
+    );
+
+    const saveButton = getByText(/Salvar Contato/i).parent;
+    fireEvent.press(saveButton!);
+    expect(onSave).not.toHaveBeenCalled();
+
+    fireEvent.changeText(getByPlaceholderText(/Digite o nome completo/i), "Ana");
+    fireEvent.changeText(
+      getByPlaceholderText(/Ex: Cônjuge, Pai, Irmã/i),
+      "Mãe",
+    );
+    fireEvent.changeText(getByPlaceholderText(/\+55/), "11999999999");
+
+    fireEvent.press(saveButton!);
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fullName: "Ana",
+        relationship: "Mãe",
+        phoneNumber: "11999999999",
+        isPrimary: false,
+      }),
+    );
+  });
+
+  it("pre-fills inputs and preserves the id when editing an existing contact", () => {
+    const onSave = jest.fn();
+    const initialContact: EmergencyContact = {
+      id: "contact_123",
+      fullName: "Marcos",
+      relationship: "Irmão",
+      phoneNumber: "11988887777",
+      isPrimary: true,
+    };
+
+    const { getByDisplayValue, getByText } = render(
+      <AddContactBottomSheet
+        {...baseProps}
+        initialContact={initialContact}
+        onSave={onSave}
+      />,
+    );
+
+    expect(getByDisplayValue("Marcos")).toBeTruthy();
+    expect(getByDisplayValue("Irmão")).toBeTruthy();
+    expect(getByDisplayValue("11988887777")).toBeTruthy();
+
+    fireEvent.changeText(getByDisplayValue("Marcos"), "Marcos Matsuda");
+    fireEvent.press(getByText(/Salvar Contato/i).parent!);
+
+    expect(onSave).toHaveBeenCalledWith({
+      id: "contact_123",
+      fullName: "Marcos Matsuda",
+      relationship: "Irmão",
+      phoneNumber: "11988887777",
+      isPrimary: true,
+    });
+  });
+
+  it("shows the edit header when editing an existing contact", () => {
+    const initialContact: EmergencyContact = {
+      id: "contact_1",
+      fullName: "Ana",
+      relationship: "Mãe",
+      phoneNumber: "11999",
+      isPrimary: false,
+    };
+    const { getByText } = render(
+      <AddContactBottomSheet
+        {...baseProps}
+        initialContact={initialContact}
+      />,
+    );
+
+    expect(getByText(/Editar Contato/i)).toBeTruthy();
+  });
+
+  it("shows the add-primary header when creating the first contact", () => {
+    const { getByText } = render(
+      <AddContactBottomSheet {...baseProps} isPrimary />,
+    );
+
+    expect(getByText(/Adicionar Contato Principal/i)).toBeTruthy();
+  });
+});

--- a/src/presentation/components/add-contact-bottom-sheet.tsx
+++ b/src/presentation/components/add-contact-bottom-sheet.tsx
@@ -8,7 +8,9 @@ import {
   Platform,
   ScrollView,
 } from "react-native";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { ChevronLeft } from "lucide-react-native";
 import { EmergencyContact } from "@domain/entities/emergency-info.entity";
 import { tokens } from "@presentation/theme/design-tokens";
 
@@ -17,6 +19,7 @@ interface AddContactBottomSheetProps {
   onClose: () => void;
   onSave: (contact: EmergencyContact) => void;
   isPrimary: boolean;
+  initialContact?: EmergencyContact | null;
 }
 
 export function AddContactBottomSheet({
@@ -24,39 +27,63 @@ export function AddContactBottomSheet({
   onClose,
   onSave,
   isPrimary,
+  initialContact = null,
 }: AddContactBottomSheetProps) {
+  const { t } = useTranslation();
   const [fullName, setFullName] = useState("");
   const [relationship, setRelationship] = useState("");
   const [phoneNumber, setPhoneNumber] = useState("");
+
+  const isEditing = initialContact !== null;
+
+  useEffect(() => {
+    if (!visible) {
+      return;
+    }
+    setFullName(initialContact?.fullName ?? "");
+    setRelationship(initialContact?.relationship ?? "");
+    setPhoneNumber(initialContact?.phoneNumber ?? "");
+  }, [visible, initialContact]);
+
+  const resetFields = () => {
+    setFullName("");
+    setRelationship("");
+    setPhoneNumber("");
+  };
 
   const handleSave = () => {
     if (!fullName.trim() || !relationship.trim() || !phoneNumber.trim()) {
       return;
     }
 
-    const newContact: EmergencyContact = {
-      id: `contact_${Date.now()}`,
+    const contact: EmergencyContact = {
+      id: initialContact?.id ?? `contact_${Date.now()}`,
       fullName: fullName.trim(),
       relationship: relationship.trim(),
       phoneNumber: phoneNumber.trim(),
-      isPrimary,
+      isPrimary: initialContact?.isPrimary ?? isPrimary,
     };
 
-    onSave(newContact);
-
-    // Reset fields
-    setFullName("");
-    setRelationship("");
-    setPhoneNumber("");
+    onSave(contact);
+    resetFields();
     onClose();
   };
 
   const handleClose = () => {
-    setFullName("");
-    setRelationship("");
-    setPhoneNumber("");
+    resetFields();
     onClose();
   };
+
+  const headerLabel = isEditing
+    ? t("emergencySetup.editContactHeader")
+    : isPrimary
+      ? t("emergencySetup.addPrimaryContactHeader")
+      : t("emergencySetup.addContactHeader");
+
+  const canSubmit =
+    fullName.trim().length > 0 &&
+    relationship.trim().length > 0 &&
+    phoneNumber.trim().length > 0;
 
   return (
     <Modal
@@ -70,107 +97,117 @@ export function AddContactBottomSheet({
         onPress={handleClose}
       >
         <KeyboardAvoidingView
-          behavior={Platform.OS === "ios" ? "padding" : "height"}
+          behavior={Platform.OS === "ios" ? "padding" : undefined}
           keyboardVerticalOffset={Platform.OS === "ios" ? 0 : 20}
         >
-          <Pressable
-            className="bg-light-bg dark:bg-background-primary rounded-t-3xl"
-            onPress={(e) => e.stopPropagation()}
+          <View
+            className="bg-light-bg dark:bg-background-primary rounded-t-3xl max-h-[92%]"
+            onStartShouldSetResponder={() => true}
           >
+            <View className="items-center pt-3 pb-2">
+              <View className="w-12 h-1 bg-light-border dark:bg-ui-border rounded-full" />
+            </View>
+
+            <View className="flex-row items-center justify-between px-4 pt-2 pb-4 border-b border-light-border dark:border-ui-border">
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={t("common.back")}
+                className="w-10 h-10 items-center justify-center"
+                onPress={handleClose}
+              >
+                <ChevronLeft size={24} color={tokens.colors.text.secondary} />
+              </Pressable>
+              <Text className="text-base font-semibold text-light-text dark:text-text-primary">
+                {headerLabel}
+              </Text>
+              <View className="w-10" />
+            </View>
+
             <ScrollView
               className="w-full max-w-[500px] self-center"
               showsVerticalScrollIndicator={false}
               keyboardShouldPersistTaps="handled"
-              contentContainerStyle={{ paddingBottom: 40 }}
+              contentContainerStyle={{ paddingBottom: 24 }}
             >
-              <View className="items-center pt-4 pb-2">
-                <View className="w-12 h-1 bg-light-border dark:bg-ui-border rounded-full mb-4" />
-                <Pressable
-                  className="absolute left-6 top-4 w-10 h-10 items-center justify-center"
-                  onPress={handleClose}
-                >
-                  <Text className="text-2xl text-light-text dark:text-text-primary">
-                    ←
-                  </Text>
-                </Pressable>
-                <Text className="text-base text-light-textSecondary dark:text-text-secondary">
-                  {isPrimary ? "Add Primary Contact" : "Add Emergency Contact"}
-                </Text>
-              </View>
-
               <View className="px-6 py-6">
                 <Text className="text-2xl font-bold text-light-text dark:text-text-primary mb-6">
-                  Contact Information
+                  {t("emergencySetup.contactSheetTitle")}
                 </Text>
 
                 <View className="mb-4">
                   <Text className="text-sm text-light-textSecondary dark:text-text-secondary mb-2">
-                    Full Name
+                    {t("emergencySetup.contactFullName")}
                   </Text>
                   <TextInput
                     className="bg-light-bgSecondary dark:bg-background-secondary rounded-xl px-4 py-3 text-light-text dark:text-text-primary"
-                    placeholder="Enter full name"
+                    placeholder={t("emergencySetup.contactFullNamePlaceholder")}
                     placeholderTextColor={tokens.colors.text.tertiary}
                     value={fullName}
                     onChangeText={setFullName}
+                    autoCapitalize="words"
+                    returnKeyType="next"
                   />
                 </View>
 
                 <View className="mb-4">
                   <Text className="text-sm text-light-textSecondary dark:text-text-secondary mb-2">
-                    Relationship
+                    {t("emergencySetup.contactRelationship")}
                   </Text>
                   <TextInput
                     className="bg-light-bgSecondary dark:bg-background-secondary rounded-xl px-4 py-3 text-light-text dark:text-text-primary"
-                    placeholder="e.g. Spouse, Parent, Sibling"
+                    placeholder={t(
+                      "emergencySetup.contactRelationshipPlaceholder",
+                    )}
                     placeholderTextColor={tokens.colors.text.tertiary}
                     value={relationship}
                     onChangeText={setRelationship}
+                    autoCapitalize="words"
+                    returnKeyType="next"
                   />
                 </View>
 
                 <View className="mb-6">
                   <Text className="text-sm text-light-textSecondary dark:text-text-secondary mb-2">
-                    Phone Number
+                    {t("emergencySetup.contactPhoneNumber")}
                   </Text>
                   <TextInput
                     className="bg-light-bgSecondary dark:bg-background-secondary rounded-xl px-4 py-3 text-light-text dark:text-text-primary"
-                    placeholder="+1 (555) 0123"
+                    placeholder={t(
+                      "emergencySetup.contactPhoneNumberPlaceholder",
+                    )}
                     placeholderTextColor={tokens.colors.text.tertiary}
                     keyboardType="phone-pad"
                     value={phoneNumber}
                     onChangeText={setPhoneNumber}
+                    returnKeyType="done"
+                    onSubmitEditing={canSubmit ? handleSave : undefined}
                   />
                 </View>
 
                 <Pressable
+                  accessibilityRole="button"
+                  accessibilityState={{ disabled: !canSubmit }}
                   className={`rounded-xl py-4 items-center ${
-                    fullName.trim() && relationship.trim() && phoneNumber.trim()
+                    canSubmit
                       ? "bg-primary-main active:bg-primary-dark"
                       : "bg-light-border dark:bg-ui-border"
                   }`}
-                  disabled={
-                    !fullName.trim() ||
-                    !relationship.trim() ||
-                    !phoneNumber.trim()
-                  }
+                  disabled={!canSubmit}
                   onPress={handleSave}
                 >
                   <Text
                     className={`text-base font-bold ${
-                      fullName.trim() &&
-                      relationship.trim() &&
-                      phoneNumber.trim()
+                      canSubmit
                         ? "text-light-text dark:text-text-primary"
                         : "text-light-textSecondary dark:text-text-secondary"
                     }`}
                   >
-                    Save Contact
+                    {t("emergencySetup.saveContact")}
                   </Text>
                 </Pressable>
               </View>
             </ScrollView>
-          </Pressable>
+          </View>
         </KeyboardAvoidingView>
       </Pressable>
     </Modal>

--- a/src/presentation/components/add-contact-bottom-sheet.tsx
+++ b/src/presentation/components/add-contact-bottom-sheet.tsx
@@ -3,7 +3,6 @@ import {
   Text,
   Pressable,
   Modal,
-  TextInput,
   KeyboardAvoidingView,
   Platform,
   ScrollView,
@@ -12,6 +11,7 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ChevronLeft } from "lucide-react-native";
 import { EmergencyContact } from "@domain/entities/emergency-info.entity";
+import { TextInputField } from "@presentation/components/text-input-field";
 import { tokens } from "@presentation/theme/design-tokens";
 
 interface AddContactBottomSheetProps {
@@ -130,88 +130,66 @@ export function AddContactBottomSheet({
             </View>
 
             <ScrollView
-              className="w-full"
+              className="flex-1"
               showsVerticalScrollIndicator={false}
               keyboardShouldPersistTaps="handled"
-              contentContainerStyle={{ paddingBottom: 24 }}
+              contentContainerClassName="px-6 py-6"
             >
-              <View className="w-full max-w-[500px] self-center px-6 py-6">
-                <Text className="text-2xl font-bold text-light-text dark:text-text-primary mb-6">
-                  {t("emergencySetup.contactSheetTitle")}
-                </Text>
+              <Text className="text-2xl font-bold text-light-text dark:text-text-primary mb-6">
+                {t("emergencySetup.contactSheetTitle")}
+              </Text>
 
-                <View className="mb-4">
-                  <Text className="text-sm text-light-textSecondary dark:text-text-secondary mb-2">
-                    {t("emergencySetup.contactFullName")}
-                  </Text>
-                  <TextInput
-                    className="bg-light-bgSecondary dark:bg-background-secondary rounded-xl px-4 py-3 text-light-text dark:text-text-primary"
-                    placeholder={t("emergencySetup.contactFullNamePlaceholder")}
-                    placeholderTextColor={tokens.colors.text.tertiary}
-                    value={fullName}
-                    onChangeText={setFullName}
-                    autoCapitalize="words"
-                    returnKeyType="next"
-                  />
-                </View>
+              <TextInputField
+                label={t("emergencySetup.contactFullName")}
+                placeholder={t("emergencySetup.contactFullNamePlaceholder")}
+                value={fullName}
+                onChangeText={setFullName}
+                autoCapitalize="words"
+                returnKeyType="next"
+              />
 
-                <View className="mb-4">
-                  <Text className="text-sm text-light-textSecondary dark:text-text-secondary mb-2">
-                    {t("emergencySetup.contactRelationship")}
-                  </Text>
-                  <TextInput
-                    className="bg-light-bgSecondary dark:bg-background-secondary rounded-xl px-4 py-3 text-light-text dark:text-text-primary"
-                    placeholder={t(
-                      "emergencySetup.contactRelationshipPlaceholder",
-                    )}
-                    placeholderTextColor={tokens.colors.text.tertiary}
-                    value={relationship}
-                    onChangeText={setRelationship}
-                    autoCapitalize="words"
-                    returnKeyType="next"
-                  />
-                </View>
+              <TextInputField
+                label={t("emergencySetup.contactRelationship")}
+                placeholder={t(
+                  "emergencySetup.contactRelationshipPlaceholder",
+                )}
+                value={relationship}
+                onChangeText={setRelationship}
+                autoCapitalize="words"
+                returnKeyType="next"
+              />
 
-                <View className="mb-6">
-                  <Text className="text-sm text-light-textSecondary dark:text-text-secondary mb-2">
-                    {t("emergencySetup.contactPhoneNumber")}
-                  </Text>
-                  <TextInput
-                    className="bg-light-bgSecondary dark:bg-background-secondary rounded-xl px-4 py-3 text-light-text dark:text-text-primary"
-                    placeholder={t(
-                      "emergencySetup.contactPhoneNumberPlaceholder",
-                    )}
-                    placeholderTextColor={tokens.colors.text.tertiary}
-                    keyboardType="phone-pad"
-                    value={phoneNumber}
-                    onChangeText={setPhoneNumber}
-                    returnKeyType="done"
-                    onSubmitEditing={canSubmit ? handleSave : undefined}
-                  />
-                </View>
+              <TextInputField
+                label={t("emergencySetup.contactPhoneNumber")}
+                placeholder={t("emergencySetup.contactPhoneNumberPlaceholder")}
+                value={phoneNumber}
+                onChangeText={setPhoneNumber}
+                keyboardType="phone-pad"
+                returnKeyType="done"
+                onSubmitEditing={canSubmit ? handleSave : undefined}
+              />
 
-                <Pressable
-                  accessibilityRole="button"
-                  accessibilityState={{ disabled: !canSubmit }}
-                  className={`rounded-xl py-4 items-center ${
+              <Pressable
+                accessibilityRole="button"
+                accessibilityState={{ disabled: !canSubmit }}
+                className={`rounded-xl py-4 items-center mt-2 ${
+                  canSubmit
+                    ? "bg-primary-main active:bg-primary-dark"
+                    : "bg-light-border dark:bg-ui-border"
+                }`}
+                disabled={!canSubmit}
+                onPress={handleSave}
+              >
+                <Text
+                  className={`text-base font-bold ${
                     canSubmit
-                      ? "bg-primary-main active:bg-primary-dark"
-                      : "bg-light-border dark:bg-ui-border"
+                      ? "text-light-text dark:text-text-primary"
+                      : "text-light-textSecondary dark:text-text-secondary"
                   }`}
-                  disabled={!canSubmit}
-                  onPress={handleSave}
                 >
-                  <Text
-                    className={`text-base font-bold ${
-                      canSubmit
-                        ? "text-light-text dark:text-text-primary"
-                        : "text-light-textSecondary dark:text-text-secondary"
-                    }`}
-                  >
-                    {t("emergencySetup.saveContact")}
-                  </Text>
-                </Pressable>
-              </View>
+                  {t("emergencySetup.saveContact")}
+                </Text>
+              </Pressable>
             </ScrollView>
           </View>
         </Pressable>

--- a/src/presentation/components/add-contact-bottom-sheet.tsx
+++ b/src/presentation/components/add-contact-bottom-sheet.tsx
@@ -90,18 +90,24 @@ export function AddContactBottomSheet({
       visible={visible}
       transparent
       animationType="slide"
+      // iPad defaults Modal to `pageSheet` (a floating centered card) unless
+      // `overFullScreen` is set explicitly — that's what was making the sheet
+      // look detached from the bottom and centered on iPad. `statusBarTranslucent`
+      // mirrors the same full-screen behavior on Android.
+      presentationStyle="overFullScreen"
+      statusBarTranslucent
       onRequestClose={handleClose}
     >
-      <Pressable
-        className="flex-1 bg-black/70 justify-end"
-        onPress={handleClose}
+      <KeyboardAvoidingView
+        className="flex-1"
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
       >
-        <KeyboardAvoidingView
-          behavior={Platform.OS === "ios" ? "padding" : undefined}
-          keyboardVerticalOffset={Platform.OS === "ios" ? 0 : 20}
+        <Pressable
+          className="flex-1 bg-black/70 justify-end"
+          onPress={handleClose}
         >
           <View
-            className="bg-light-bg dark:bg-background-primary rounded-t-3xl max-h-[92%]"
+            className="w-full bg-light-bg dark:bg-background-primary rounded-t-3xl max-h-[92%]"
             onStartShouldSetResponder={() => true}
           >
             <View className="items-center pt-3 pb-2">
@@ -124,12 +130,12 @@ export function AddContactBottomSheet({
             </View>
 
             <ScrollView
-              className="w-full max-w-[500px] self-center"
+              className="w-full"
               showsVerticalScrollIndicator={false}
               keyboardShouldPersistTaps="handled"
               contentContainerStyle={{ paddingBottom: 24 }}
             >
-              <View className="px-6 py-6">
+              <View className="w-full max-w-[500px] self-center px-6 py-6">
                 <Text className="text-2xl font-bold text-light-text dark:text-text-primary mb-6">
                   {t("emergencySetup.contactSheetTitle")}
                 </Text>
@@ -208,8 +214,8 @@ export function AddContactBottomSheet({
               </View>
             </ScrollView>
           </View>
-        </KeyboardAvoidingView>
-      </Pressable>
+        </Pressable>
+      </KeyboardAvoidingView>
     </Modal>
   );
 }

--- a/src/presentation/components/add-contact-bottom-sheet.tsx
+++ b/src/presentation/components/add-contact-bottom-sheet.tsx
@@ -5,7 +5,6 @@ import {
   Modal,
   KeyboardAvoidingView,
   Platform,
-  ScrollView,
 } from "react-native";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -90,25 +89,22 @@ export function AddContactBottomSheet({
       visible={visible}
       transparent
       animationType="slide"
-      // iPad defaults Modal to `pageSheet` (a floating centered card) unless
-      // `overFullScreen` is set explicitly — that's what was making the sheet
-      // look detached from the bottom and centered on iPad. `statusBarTranslucent`
-      // mirrors the same full-screen behavior on Android.
+      // Without overFullScreen, Modal on iPad defaults to `pageSheet` —
+      // a centered floating card instead of a true bottom sheet.
       presentationStyle="overFullScreen"
       statusBarTranslucent
       onRequestClose={handleClose}
     >
-      <KeyboardAvoidingView
-        className="flex-1"
-        behavior={Platform.OS === "ios" ? "padding" : undefined}
+      <Pressable
+        className="flex-1 bg-black/70 justify-end"
+        onPress={handleClose}
       >
-        <Pressable
-          className="flex-1 bg-black/70 justify-end"
-          onPress={handleClose}
+        <KeyboardAvoidingView
+          behavior={Platform.OS === "ios" ? "padding" : undefined}
         >
-          <View
-            className="w-full bg-light-bg dark:bg-background-primary rounded-t-3xl max-h-[92%]"
-            onStartShouldSetResponder={() => true}
+          <Pressable
+            className="w-full bg-light-bg dark:bg-background-primary rounded-t-3xl"
+            onPress={(e) => e?.stopPropagation?.()}
           >
             <View className="items-center pt-3 pb-2">
               <View className="w-12 h-1 bg-light-border dark:bg-ui-border rounded-full" />
@@ -129,12 +125,7 @@ export function AddContactBottomSheet({
               <View className="w-10" />
             </View>
 
-            <ScrollView
-              className="flex-1"
-              showsVerticalScrollIndicator={false}
-              keyboardShouldPersistTaps="handled"
-              contentContainerClassName="px-6 py-6"
-            >
+            <View className="px-6 py-6">
               <Text className="text-2xl font-bold text-light-text dark:text-text-primary mb-6">
                 {t("emergencySetup.contactSheetTitle")}
               </Text>
@@ -150,9 +141,7 @@ export function AddContactBottomSheet({
 
               <TextInputField
                 label={t("emergencySetup.contactRelationship")}
-                placeholder={t(
-                  "emergencySetup.contactRelationshipPlaceholder",
-                )}
+                placeholder={t("emergencySetup.contactRelationshipPlaceholder")}
                 value={relationship}
                 onChangeText={setRelationship}
                 autoCapitalize="words"
@@ -171,6 +160,7 @@ export function AddContactBottomSheet({
 
               <Pressable
                 accessibilityRole="button"
+                accessibilityLabel={t("emergencySetup.saveContact")}
                 accessibilityState={{ disabled: !canSubmit }}
                 className={`rounded-xl py-4 items-center mt-2 ${
                   canSubmit
@@ -190,10 +180,10 @@ export function AddContactBottomSheet({
                   {t("emergencySetup.saveContact")}
                 </Text>
               </Pressable>
-            </ScrollView>
-          </View>
-        </Pressable>
-      </KeyboardAvoidingView>
+            </View>
+          </Pressable>
+        </KeyboardAvoidingView>
+      </Pressable>
     </Modal>
   );
 }

--- a/src/presentation/components/contact-card.tsx
+++ b/src/presentation/components/contact-card.tsx
@@ -1,5 +1,5 @@
 import { View, Text, Pressable } from "react-native";
-import { X, ChevronRight, Phone } from "lucide-react-native";
+import { X, Pencil, Phone } from "lucide-react-native";
 import { tokens } from "@presentation/theme/design-tokens";
 
 interface ContactCardProps {
@@ -24,7 +24,7 @@ export function ContactCard({
   return (
     <View className="bg-light-bgSecondary dark:bg-background-secondary rounded-xl p-4 mb-3">
       <View className="flex-row items-start justify-between mb-3">
-        <View className="flex-1">
+        <View className="flex-1 pr-2">
           {isPrimary && (
             <View className="bg-primary-main/20 px-2 py-1 rounded mb-2 self-start">
               <Text className="text-xs font-bold text-primary-main tracking-wide">
@@ -39,14 +39,30 @@ export function ContactCard({
             {fullName}
           </Text>
         </View>
-        {onRemove && (
-          <Pressable
-            className="w-8 h-8 items-center justify-center"
-            onPress={onRemove}
-          >
-            <X size={18} color={tokens.colors.status.error} />
-          </Pressable>
-        )}
+        <View className="flex-row items-center">
+          {onEdit && (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Edit contact"
+              className="w-8 h-8 items-center justify-center mr-1"
+              onPress={onEdit}
+              hitSlop={6}
+            >
+              <Pencil size={16} color={tokens.colors.text.secondary} />
+            </Pressable>
+          )}
+          {onRemove && (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Remove contact"
+              className="w-8 h-8 items-center justify-center"
+              onPress={onRemove}
+              hitSlop={6}
+            >
+              <X size={18} color={tokens.colors.status.error} />
+            </Pressable>
+          )}
+        </View>
       </View>
 
       <View className="flex-row items-center justify-between">
@@ -54,16 +70,9 @@ export function ContactCard({
           <Text className="text-xs font-semibold text-light-textSecondary dark:text-text-secondary mb-1 tracking-wide">
             RELATIONSHIP
           </Text>
-          <View className="flex-row items-center">
-            <Text className="text-sm text-light-text dark:text-text-primary">
-              {relationship}
-            </Text>
-            <ChevronRight
-              size={16}
-              color={tokens.colors.text.secondary}
-              className="ml-1"
-            />
-          </View>
+          <Text className="text-sm text-light-text dark:text-text-primary">
+            {relationship}
+          </Text>
         </View>
 
         <View className="flex-1 ml-4">
@@ -71,15 +80,23 @@ export function ContactCard({
             PHONE NUMBER
           </Text>
           <View className="flex-row items-center justify-between">
-            <Text className="text-sm text-light-text dark:text-text-primary">
+            <Text
+              className="text-sm text-light-text dark:text-text-primary flex-1"
+              numberOfLines={1}
+            >
               {phoneNumber}
             </Text>
-            <Pressable
-              className="w-8 h-8 bg-status-success/20 rounded-full items-center justify-center"
-              onPress={onCall}
-            >
-              <Phone size={14} color={tokens.colors.status.success} />
-            </Pressable>
+            {onCall && (
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Call contact"
+                className="w-8 h-8 bg-status-success/20 rounded-full items-center justify-center ml-2"
+                onPress={onCall}
+                hitSlop={6}
+              >
+                <Phone size={14} color={tokens.colors.status.success} />
+              </Pressable>
+            )}
           </View>
         </View>
       </View>

--- a/src/presentation/components/pin-confirmation-bottom-sheet.tsx
+++ b/src/presentation/components/pin-confirmation-bottom-sheet.tsx
@@ -66,6 +66,10 @@ export function PinConfirmationBottomSheet({
       visible={visible}
       transparent
       animationType="slide"
+      // Without overFullScreen, Modal on iPad defaults to `pageSheet`, which
+      // renders as a centered floating card instead of a true bottom sheet.
+      presentationStyle="overFullScreen"
+      statusBarTranslucent
       onRequestClose={handleClose}
     >
       <Pressable
@@ -73,7 +77,7 @@ export function PinConfirmationBottomSheet({
         onPress={handleClose}
       >
         <Pressable
-          className="bg-light-bg dark:bg-background-primary rounded-t-3xl h-[80%]"
+          className="w-full bg-light-bg dark:bg-background-primary rounded-t-3xl h-[80%]"
           onPress={(e) => e.stopPropagation()}
         >
           <View className="flex-1 w-full max-w-[500px] self-center">

--- a/src/presentation/components/text-input-field.tsx
+++ b/src/presentation/components/text-input-field.tsx
@@ -1,4 +1,4 @@
-import { View, Text, TextInput } from "react-native";
+import { View, Text, TextInput, TextInputProps } from "react-native";
 import { tokens } from "@presentation/theme/design-tokens";
 
 interface TextInputFieldProps {
@@ -6,7 +6,10 @@ interface TextInputFieldProps {
   value?: string;
   placeholder?: string;
   onChangeText?: (text: string) => void;
-  keyboardType?: "default" | "numeric" | "email-address";
+  keyboardType?: TextInputProps["keyboardType"];
+  autoCapitalize?: TextInputProps["autoCapitalize"];
+  returnKeyType?: TextInputProps["returnKeyType"];
+  onSubmitEditing?: TextInputProps["onSubmitEditing"];
 }
 
 export function TextInputField({
@@ -15,6 +18,9 @@ export function TextInputField({
   placeholder,
   onChangeText,
   keyboardType = "default",
+  autoCapitalize,
+  returnKeyType,
+  onSubmitEditing,
 }: TextInputFieldProps) {
   return (
     <View className="mb-4">
@@ -28,6 +34,9 @@ export function TextInputField({
         value={value}
         onChangeText={onChangeText}
         keyboardType={keyboardType}
+        autoCapitalize={autoCapitalize}
+        returnKeyType={returnKeyType}
+        onSubmitEditing={onSubmitEditing}
       />
     </View>
   );

--- a/src/presentation/screens/emergency-setup-screen.tsx
+++ b/src/presentation/screens/emergency-setup-screen.tsx
@@ -51,6 +51,8 @@ export function EmergencySetupScreen() {
   const [isSaving, setIsSaving] = useState(false);
   const [showContactSheet, setShowContactSheet] = useState(false);
   const [isAddingPrimaryContact, setIsAddingPrimaryContact] = useState(false);
+  const [editingContact, setEditingContact] =
+    useState<EmergencyContact | null>(null);
 
   useEffect(() => {
     if (emergencyInfo) {
@@ -86,8 +88,13 @@ export function EmergencySetupScreen() {
     }
   };
 
-  const handleAddContact = (contact: EmergencyContact) => {
-    setContacts([...contacts, contact]);
+  const handleSaveContact = (contact: EmergencyContact) => {
+    setContacts((current) => {
+      const exists = current.some((c) => c.id === contact.id);
+      return exists
+        ? current.map((c) => (c.id === contact.id ? contact : c))
+        : [...current, contact];
+    });
   };
 
   const handleRemoveContact = (contactId: string) => {
@@ -95,8 +102,20 @@ export function EmergencySetupScreen() {
   };
 
   const openAddContactSheet = (isPrimary: boolean) => {
+    setEditingContact(null);
     setIsAddingPrimaryContact(isPrimary);
     setShowContactSheet(true);
+  };
+
+  const openEditContactSheet = (contact: EmergencyContact) => {
+    setEditingContact(contact);
+    setIsAddingPrimaryContact(contact.isPrimary);
+    setShowContactSheet(true);
+  };
+
+  const closeContactSheet = () => {
+    setShowContactSheet(false);
+    setEditingContact(null);
   };
 
   const handleSave = async () => {
@@ -308,6 +327,7 @@ export function EmergencySetupScreen() {
                   fullName={contact.fullName}
                   relationship={contact.relationship}
                   phoneNumber={contact.phoneNumber}
+                  onEdit={() => openEditContactSheet(contact)}
                   onRemove={() => handleRemoveContact(contact.id)}
                   isPrimary={contact.isPrimary}
                 />
@@ -363,9 +383,10 @@ export function EmergencySetupScreen() {
 
         <AddContactBottomSheet
           visible={showContactSheet}
-          onClose={() => setShowContactSheet(false)}
-          onSave={handleAddContact}
+          onClose={closeContactSheet}
+          onSave={handleSaveContact}
           isPrimary={isAddingPrimaryContact}
+          initialContact={editingContact}
         />
       </View>
     </SafeAreaView>

--- a/src/presentation/screens/emergency-setup-screen.tsx
+++ b/src/presentation/screens/emergency-setup-screen.tsx
@@ -51,8 +51,9 @@ export function EmergencySetupScreen() {
   const [isSaving, setIsSaving] = useState(false);
   const [showContactSheet, setShowContactSheet] = useState(false);
   const [isAddingPrimaryContact, setIsAddingPrimaryContact] = useState(false);
-  const [editingContact, setEditingContact] =
-    useState<EmergencyContact | null>(null);
+  const [editingContact, setEditingContact] = useState<EmergencyContact | null>(
+    null,
+  );
 
   useEffect(() => {
     if (emergencyInfo) {

--- a/src/shared/i18n/locales/en-US.json
+++ b/src/shared/i18n/locales/en-US.json
@@ -113,7 +113,18 @@
     "contactRequired": "Add at least one emergency contact",
     "saveProfile": "Save Emergency Profile",
     "saveError": "Failed to save",
-    "savedSuccess": "Emergency profile saved!"
+    "savedSuccess": "Emergency profile saved!",
+    "contactSheetTitle": "Contact Information",
+    "addContactHeader": "Add Emergency Contact",
+    "addPrimaryContactHeader": "Add Primary Contact",
+    "editContactHeader": "Edit Contact",
+    "contactFullName": "Full Name",
+    "contactFullNamePlaceholder": "Enter full name",
+    "contactRelationship": "Relationship",
+    "contactRelationshipPlaceholder": "e.g. Spouse, Parent, Sibling",
+    "contactPhoneNumber": "Phone Number",
+    "contactPhoneNumberPlaceholder": "+1 (555) 0123",
+    "saveContact": "Save Contact"
   },
   "guestMode": {
     "title": "Shared Documents",

--- a/src/shared/i18n/locales/pt-BR.json
+++ b/src/shared/i18n/locales/pt-BR.json
@@ -113,7 +113,18 @@
     "contactRequired": "Adicione pelo menos um contato de emergência",
     "saveProfile": "Salvar Perfil de Emergência",
     "saveError": "Não foi possível salvar",
-    "savedSuccess": "Perfil de emergência salvo!"
+    "savedSuccess": "Perfil de emergência salvo!",
+    "contactSheetTitle": "Informações do Contato",
+    "addContactHeader": "Adicionar Contato",
+    "addPrimaryContactHeader": "Adicionar Contato Principal",
+    "editContactHeader": "Editar Contato",
+    "contactFullName": "Nome Completo",
+    "contactFullNamePlaceholder": "Digite o nome completo",
+    "contactRelationship": "Relacionamento",
+    "contactRelationshipPlaceholder": "Ex: Cônjuge, Pai, Irmã",
+    "contactPhoneNumber": "Telefone",
+    "contactPhoneNumberPlaceholder": "+55 (11) 9XXXX-XXXX",
+    "saveContact": "Salvar Contato"
   },
   "guestMode": {
     "title": "Documentos Compartilhados",


### PR DESCRIPTION
## Summary

Usuário reportou dois pontos no fluxo de contatos de emergência:

1. **Não conseguia editar um contato salvo.** O \`ContactCard\` já expunha uma prop \`onEdit\`, mas o \`emergency-setup-screen\` nunca passava. O \`AddContactBottomSheet\` era um \"create-only\" — não aceitava valores iniciais.

2. **Layout do bottom sheet precisava de revisão.** Todos os labels, placeholders e o botão estavam hard-coded em inglês (único componente do app fora do i18n), um \`ChevronRight\` ao lado de \"RELATIONSHIP\" sugeria que a linha era tappável sem fazer nada, e o botão \"telefone\" aparecia dentro da tela de edição mesmo sem handler de chamada.

## Changes

- **\`AddContactBottomSheet\`** aceita \`initialContact?: EmergencyContact | null\`. Quando presente, o sheet pré-preenche os campos, muda o header pra \"Editar Contato\" e preserva \`id\`/\`isPrimary\` do contato original no save (o repositório faz upsert por id). Todas as strings agora vão pelo i18n em pt-BR e en-US. Header reformatado com chevron-back alinhado como em outras telas.

- **\`ContactCard\`** ganhou um ícone de lápis ao lado do X pra disparar \`onEdit\`. O botão de telefone agora só aparece se \`onCall\` for fornecido (antes ficava \"órfão\" na tela de setup). O \`ChevronRight\` enganoso foi removido.

- **\`emergency-setup-screen\`** passa a manter \`editingContact\` separado. Abrir pelo lápis chama \`openEditContactSheet\`. O handler \`handleSaveContact\` faz upsert por id (mapeia se existe, faz append se não), em vez de sempre dar append como o \`handleAddContact\` antigo.

## Test plan

- [x] \`npm test\` — 837 passando (5 novos em \`add-contact-bottom-sheet.test.tsx\`: localização, disabled até preencher, pré-fill no edit, preserva id no save, headers das três variantes)
- [x] \`npx tsc --noEmit\` sem novos erros
- [ ] QA: Settings → Emergency → adicionar contato → voltar → abrir de novo → tocar no lápis → sheet abre com os campos preenchidos → editar e salvar → card mostra valores atualizados
- [ ] QA: layout do sheet em pt-BR mostra labels e placeholders em português
- [ ] QA: layout do sheet com teclado aberto não corta o botão de salvar (KeyboardAvoidingView + max-h 92%)