### PR TITLE
feat(profile): face-framing mask for profile photo capture

### DIFF
--- a/src/presentation/components/profile-photo-camera-modal.tsx
+++ b/src/presentation/components/profile-photo-camera-modal.tsx
@@ -23,8 +23,8 @@ interface ProfilePhotoCameraModalProps {
 // Stadium-shaped face guide (vertically oriented). Height > width keeps it
 // matching the natural face aspect, and the capped corners read as an oval
 // without needing SVG to draw a true ellipse.
-const GUIDE_WIDTH = 260;
-const GUIDE_HEIGHT = 340;
+const GUIDE_WIDTH = 320;
+const GUIDE_HEIGHT = 420;
 
 export function ProfilePhotoCameraModal({
   visible,

--- a/src/presentation/components/profile-photo-camera-modal.tsx
+++ b/src/presentation/components/profile-photo-camera-modal.tsx
@@ -1,0 +1,196 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  Modal,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { CameraView, useCameraPermissions } from "expo-camera";
+import * as ImageManipulator from "expo-image-manipulator";
+import { ChevronLeft, RefreshCw } from "lucide-react-native";
+import { useTranslation } from "react-i18next";
+import { tokens } from "@presentation/theme/design-tokens";
+
+interface ProfilePhotoCameraModalProps {
+  visible: boolean;
+  onClose: () => void;
+  onCapture: (uri: string) => void;
+}
+
+// Stadium-shaped face guide (vertically oriented). Height > width keeps it
+// matching the natural face aspect, and the capped corners read as an oval
+// without needing SVG to draw a true ellipse.
+const GUIDE_WIDTH = 260;
+const GUIDE_HEIGHT = 340;
+
+export function ProfilePhotoCameraModal({
+  visible,
+  onClose,
+  onCapture,
+}: ProfilePhotoCameraModalProps) {
+  const { t } = useTranslation();
+  const [permission, requestPermission] = useCameraPermissions();
+  const cameraRef = useRef<CameraView>(null);
+  const [isCapturing, setIsCapturing] = useState(false);
+  const [facing, setFacing] = useState<"front" | "back">("front");
+
+  useEffect(() => {
+    if (visible && permission && !permission.granted && permission.canAskAgain) {
+      requestPermission();
+    }
+  }, [visible, permission, requestPermission]);
+
+  const handleCapture = async () => {
+    if (!cameraRef.current || isCapturing) {
+      return;
+    }
+    setIsCapturing(true);
+    try {
+      const photo = await cameraRef.current.takePictureAsync({
+        quality: 0.85,
+        skipProcessing: false,
+      });
+      if (!photo) {
+        return;
+      }
+      // Avatar is displayed as a circle; centre-crop to a square so the
+      // saved file doesn't carry letterboxing.
+      const size = Math.min(photo.width, photo.height);
+      const originX = Math.max(0, (photo.width - size) / 2);
+      const originY = Math.max(0, (photo.height - size) / 2);
+      const cropped = await ImageManipulator.manipulateAsync(
+        photo.uri,
+        [{ crop: { originX, originY, width: size, height: size } }],
+        { compress: 0.85, format: ImageManipulator.SaveFormat.JPEG },
+      );
+      onCapture(cropped.uri);
+      onClose();
+    } catch (error) {
+      console.error("Error capturing profile photo:", error);
+    } finally {
+      setIsCapturing(false);
+    }
+  };
+
+  const handleFlipFacing = () => {
+    if (isCapturing) return;
+    setFacing((current) => (current === "front" ? "back" : "front"));
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      presentationStyle="overFullScreen"
+      statusBarTranslucent
+      animationType="slide"
+      onRequestClose={onClose}
+    >
+      <View className="flex-1 bg-black">
+        {permission?.granted ? (
+          <CameraView
+            ref={cameraRef}
+            style={StyleSheet.absoluteFill}
+            facing={facing}
+          >
+            <View
+              pointerEvents="none"
+              className="flex-1 items-center justify-center"
+            >
+              <View
+                style={{
+                  width: GUIDE_WIDTH,
+                  height: GUIDE_HEIGHT,
+                  borderRadius: GUIDE_WIDTH / 2,
+                  borderWidth: 3,
+                  borderColor: "rgba(255,255,255,0.9)",
+                  borderStyle: "dashed",
+                }}
+              />
+              <Text className="text-white text-base font-semibold mt-6 mx-8 text-center">
+                {t("profile.facePhotoGuide")}
+              </Text>
+            </View>
+          </CameraView>
+        ) : (
+          <View className="flex-1 items-center justify-center px-8">
+            <Text className="text-white text-center mb-4 text-base">
+              {permission === null
+                ? t("common.loading")
+                : t("addDocument.cameraPermissionMsg")}
+            </Text>
+            {permission && !permission.granted && permission.canAskAgain && (
+              <Pressable
+                accessibilityRole="button"
+                onPress={requestPermission}
+                className="bg-primary-main px-6 py-3 rounded-xl"
+              >
+                <Text className="text-white font-semibold">
+                  {t("common.continue")}
+                </Text>
+              </Pressable>
+            )}
+          </View>
+        )}
+
+        <SafeAreaView
+          edges={["top"]}
+          pointerEvents="box-none"
+          className="absolute top-0 left-0 right-0"
+        >
+          <View className="flex-row justify-between items-center px-4 py-2">
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={t("common.close")}
+              className="w-10 h-10 items-center justify-center bg-black/50 rounded-full"
+              onPress={onClose}
+            >
+              <ChevronLeft color="white" size={24} />
+            </Pressable>
+            {permission?.granted && (
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={t("profile.flipCamera")}
+                className="w-10 h-10 items-center justify-center bg-black/50 rounded-full"
+                onPress={handleFlipFacing}
+              >
+                <RefreshCw color="white" size={20} />
+              </Pressable>
+            )}
+          </View>
+        </SafeAreaView>
+
+        <SafeAreaView
+          edges={["bottom"]}
+          pointerEvents="box-none"
+          className="absolute bottom-0 left-0 right-0"
+        >
+          <View className="items-center pb-8">
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={t("profile.takePhoto")}
+              accessibilityState={{ disabled: isCapturing }}
+              disabled={isCapturing || !permission?.granted}
+              onPress={handleCapture}
+              className="w-20 h-20 rounded-full items-center justify-center"
+              style={{
+                backgroundColor: "rgba(255,255,255,0.25)",
+                borderWidth: 4,
+                borderColor: "white",
+              }}
+            >
+              {isCapturing ? (
+                <ActivityIndicator color={tokens.colors.text.primary} />
+              ) : (
+                <View className="w-14 h-14 rounded-full bg-white" />
+              )}
+            </Pressable>
+          </View>
+        </SafeAreaView>
+      </View>
+    </Modal>
+  );
+}

--- a/src/presentation/components/profile-photo-camera-modal.tsx
+++ b/src/presentation/components/profile-photo-camera-modal.tsx
@@ -38,7 +38,12 @@ export function ProfilePhotoCameraModal({
   const [facing, setFacing] = useState<"front" | "back">("front");
 
   useEffect(() => {
-    if (visible && permission && !permission.granted && permission.canAskAgain) {
+    if (
+      visible &&
+      permission &&
+      !permission.granted &&
+      permission.canAskAgain
+    ) {
       requestPermission();
     }
   }, [visible, permission, requestPermission]);

--- a/src/presentation/hooks/use-profile-photo.ts
+++ b/src/presentation/hooks/use-profile-photo.ts
@@ -1,117 +1,49 @@
-import { useState, useCallback } from "react";
+import { useCallback, useState } from "react";
 import * as ImagePicker from "expo-image-picker";
 import { Alert } from "react-native";
 
-type OnPhotoUpdateCallback = () => void;
-
-export function useProfilePhoto(onPhotoUpdate?: OnPhotoUpdateCallback) {
+export function useProfilePhoto() {
   const [isLoading, setIsLoading] = useState(false);
 
-  const requestPermissions = useCallback(async () => {
-    const { status: cameraStatus } =
-      await ImagePicker.requestCameraPermissionsAsync();
-    const { status: mediaStatus } =
-      await ImagePicker.requestMediaLibraryPermissionsAsync();
+  const pickFromGallery = useCallback(async (): Promise<string | null> => {
+    setIsLoading(true);
+    try {
+      const { status } =
+        await ImagePicker.requestMediaLibraryPermissionsAsync();
+      if (status !== "granted") {
+        Alert.alert(
+          "Permission Required",
+          "Media library permission is required to select photos.",
+          [{ text: "OK" }],
+        );
+        return null;
+      }
 
-    return {
-      camera: cameraStatus === "granted",
-      mediaLibrary: mediaStatus === "granted",
-    };
+      const result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        allowsEditing: true,
+        aspect: [1, 1],
+        quality: 0.8,
+        base64: false,
+      });
+
+      if (!result.canceled && result.assets && result.assets.length > 0) {
+        return result.assets[0].uri;
+      }
+      return null;
+    } catch (error) {
+      console.error("Error picking image:", error);
+      Alert.alert("Error", "Failed to pick image. Please try again.", [
+        { text: "OK" },
+      ]);
+      return null;
+    } finally {
+      setIsLoading(false);
+    }
   }, []);
 
-  const pickImage = useCallback(
-    async (source: "camera" | "gallery") => {
-      setIsLoading(true);
-      try {
-        const permissions = await requestPermissions();
-
-        if (source === "camera" && !permissions.camera) {
-          Alert.alert(
-            "Permission Required",
-            "Camera permission is required to take photos. Please enable it in your device settings.",
-            [{ text: "OK" }],
-          );
-          return null;
-        }
-
-        if (source === "gallery" && !permissions.mediaLibrary) {
-          Alert.alert(
-            "Permission Required",
-            "Media library permission is required to select photos. Please enable it in your device settings.",
-            [{ text: "OK" }],
-          );
-          return null;
-        }
-
-        const options: ImagePicker.ImagePickerOptions = {
-          mediaTypes: ImagePicker.MediaTypeOptions.Images,
-          allowsEditing: true,
-          aspect: [1, 1],
-          quality: 0.8,
-          base64: false,
-        };
-
-        let result: ImagePicker.ImagePickerResult;
-
-        if (source === "camera") {
-          result = await ImagePicker.launchCameraAsync(options);
-        } else {
-          result = await ImagePicker.launchImageLibraryAsync(options);
-        }
-
-        if (!result.canceled && result.assets && result.assets.length > 0) {
-          const photoUri = result.assets[0].uri;
-          return photoUri; // ← SÓ RETORNA URI, sem persistir
-        }
-
-        return null;
-      } catch (error) {
-        console.error("Error picking image:", error);
-        Alert.alert("Error", "Failed to pick image. Please try again.", [
-          { text: "OK" },
-        ]);
-        return null;
-      } finally {
-        setIsLoading(false);
-      }
-    },
-    [requestPermissions],
-  );
-
-  const showImagePickerOptions = useCallback(async () => {
-    return new Promise<string | null>((resolve) => {
-      Alert.alert(
-        "Choose Profile Photo",
-        "Select an option to choose your profile photo",
-        [
-          {
-            text: "Cancel",
-            style: "cancel",
-            onPress: () => resolve(null),
-          },
-          {
-            text: "Take Photo",
-            onPress: async () => {
-              const uri = await pickImage("camera");
-              resolve(uri);
-            },
-          },
-          {
-            text: "Choose from Gallery",
-            onPress: async () => {
-              const uri = await pickImage("gallery");
-              resolve(uri);
-            },
-          },
-        ],
-      );
-    });
-  }, [pickImage]);
-
   return {
-    pickImage,
-    showImagePickerOptions,
+    pickFromGallery,
     isLoading,
-    requestPermissions,
   };
 }

--- a/src/presentation/screens/profile-setup-screen.tsx
+++ b/src/presentation/screens/profile-setup-screen.tsx
@@ -12,6 +12,7 @@ import { useRouter, useFocusEffect } from "expo-router";
 import { useUserProfile } from "@presentation/hooks/use-user-profile";
 import { useProfilePhoto } from "@presentation/hooks/use-profile-photo";
 import { UserAvatar } from "@presentation/components/user-avatar";
+import { ProfilePhotoCameraModal } from "@presentation/components/profile-photo-camera-modal";
 import { useTranslation } from "react-i18next";
 import { tokens } from "@presentation/theme/design-tokens";
 
@@ -20,13 +21,10 @@ export function ProfileSetupScreen() {
   const router = useRouter();
   const [photoUri, setPhotoUri] = useState<string | null>(null);
   const { profile, saveProfile, reloadProfile } = useUserProfile();
-  const {
-    pickImage,
-    showImagePickerOptions,
-    isLoading: isPhotoLoading,
-  } = useProfilePhoto();
+  const { pickFromGallery, isLoading: isPhotoLoading } = useProfilePhoto();
   const [name, setName] = useState("");
   const [isSaving, setIsSaving] = useState(false);
+  const [isCameraOpen, setIsCameraOpen] = useState(false);
 
   useFocusEffect(
     React.useCallback(() => {
@@ -71,11 +69,27 @@ export function ProfileSetupScreen() {
     }
   };
 
-  const handleSelectPhoto = async () => {
-    const newUri = await showImagePickerOptions();
-    if (newUri) {
-      setPhotoUri(newUri); // ← Apenas atualiza estado local
-    }
+  const handleSelectPhoto = () => {
+    Alert.alert(t("profile.photoSheetTitle"), "", [
+      {
+        text: t("profile.takePhoto"),
+        onPress: () => setIsCameraOpen(true),
+      },
+      {
+        text: t("profile.chooseFromGallery"),
+        onPress: async () => {
+          const newUri = await pickFromGallery();
+          if (newUri) {
+            setPhotoUri(newUri);
+          }
+        },
+      },
+      { text: t("common.cancel"), style: "cancel" },
+    ]);
+  };
+
+  const handlePhotoCaptured = (uri: string) => {
+    setPhotoUri(uri);
   };
 
   return (
@@ -133,6 +147,12 @@ export function ProfileSetupScreen() {
           )}
         </Pressable>
       </View>
+
+      <ProfilePhotoCameraModal
+        visible={isCameraOpen}
+        onClose={() => setIsCameraOpen(false)}
+        onCapture={handlePhotoCaptured}
+      />
     </SafeAreaView>
   );
 }

--- a/src/shared/i18n/locales/en-US.json
+++ b/src/shared/i18n/locales/en-US.json
@@ -220,7 +220,12 @@
     "yourName": "YOUR NAME",
     "namePlaceholder": "Enter your name",
     "nameRequired": "Name must be at least 2 characters",
-    "saveChanges": "Save Changes"
+    "saveChanges": "Save Changes",
+    "photoSheetTitle": "Profile Photo",
+    "takePhoto": "Take Photo",
+    "chooseFromGallery": "Choose from Gallery",
+    "flipCamera": "Flip camera",
+    "facePhotoGuide": "Position your face inside the circle"
   },
   "customDocType": {
     "createTitle": "Create Document Type",

--- a/src/shared/i18n/locales/pt-BR.json
+++ b/src/shared/i18n/locales/pt-BR.json
@@ -220,7 +220,12 @@
     "yourName": "SEU NOME",
     "namePlaceholder": "Digite seu nome",
     "nameRequired": "Nome deve ter pelo menos 2 caracteres",
-    "saveChanges": "Salvar Alterações"
+    "saveChanges": "Salvar Alterações",
+    "photoSheetTitle": "Foto de Perfil",
+    "takePhoto": "Tirar Foto",
+    "chooseFromGallery": "Escolher da Galeria",
+    "flipCamera": "Inverter câmera",
+    "facePhotoGuide": "Posicione seu rosto dentro do círculo"
   },
   "customDocType": {
     "createTitle": "Criar Tipo de Documento",


### PR DESCRIPTION
## Summary

Usuário pediu uma máscara pra encaixar o rosto na captura da foto de perfil. O \`expo-image-picker.launchCameraAsync\` abre a UI nativa do sistema, que **não aceita overlay custom** — impossível desenhar um guia por cima. Substituído por um modal de câmera custom usando \`expo-camera\` (já em deps, mesmo módulo usado pelo \`camera-scanner\`).

## Mudanças

- **Novo \`ProfilePhotoCameraModal\`**: full-screen com \`CameraView\`, default front camera, guia em formato de estádio (260×340, \`borderRadius = width/2\`, borda dashed branca) centralizado, caption \"Posicione seu rosto dentro do círculo\", botão de flip câmera e um shutter grande estilo iOS no rodapé.
- **Crop automático**: após capturar, o \`expo-image-manipulator\` corta a foto pro quadrado central (o \`UserAvatar\` renderiza redondo, então quadrado é suficiente e evita letterbox).
- **\`useProfilePhoto\` simplificado**: ficou só com \`pickFromGallery()\`. O caminho de câmera agora é dirigido pela tela porque precisa de state de modal — mistura de UI state com hook ficava confuso.
- **\`profile-setup-screen\`** mostra um Alert com 3 opções (Tirar Foto / Escolher da Galeria / Cancelar) e monta o modal novo.
- Strings em pt-BR e en-US: \`photoSheetTitle\`, \`takePhoto\`, \`chooseFromGallery\`, \`flipCamera\`, \`facePhotoGuide\`.

## Decisões

**Por que estádio (pill vertical) em vez de círculo perfeito ou elipse?** Rosto humano é mais alto que largo, pill vertical é o formato que Face ID, Apple Pay, e a maior parte dos apps bancários usam. Evito SVG só pra desenhar uma elipse e mantenho tudo em Views.

**Por que não crop pela área do guia?** O guia é só visual — a foto é cropada pelo quadrado central, suficiente pro avatar redondo. Se quiser cropar mais agressivamente no futuro, trocar o originX/Y é trivial.

## Test plan

- [x] \`npm test\` — 837 passando (não adicionei tests pro modal — requer mock de expo-camera)
- [x] \`npx tsc --noEmit\` sem novos erros
- [ ] QA iOS: Profile Setup → tocar na foto → \"Tirar Foto\" → câmera frontal abre com guia oval → capturar → foto aparece circular no avatar
- [ ] QA iOS: permission negada → tela de erro com botão \"Continuar\" re-solicita
- [ ] QA iOS: botão flip funciona e câmera troca front/back
- [ ] QA iOS: galeria ainda funciona (fluxo antigo via expo-image-picker)
- [ ] QA Android: mesmo fluxo