### PR TITLE
fix(profile): stop redirecting users with saved profile to /profile-setup

### DIFF
--- a/src/presentation/hooks/use-user-profile.ts
+++ b/src/presentation/hooks/use-user-profile.ts
@@ -3,7 +3,7 @@ import { UserProfileInput } from "@domain/entities/user-profile.entity";
 import { useProfileStore } from "@stores/profile.store";
 
 export function useUserProfile() {
-  const { profile, isLoading, error, loadProfile, saveProfile } =
+  const { profile, isLoading, hasLoaded, error, loadProfile, saveProfile } =
     useProfileStore();
 
   useEffect(() => {
@@ -13,6 +13,7 @@ export function useUserProfile() {
   return {
     profile,
     isLoading,
+    hasLoaded,
     error,
     saveProfile,
     reloadProfile: loadProfile,

--- a/src/presentation/screens/wallet-home-screen.tsx
+++ b/src/presentation/screens/wallet-home-screen.tsx
@@ -35,21 +35,25 @@ export function WalletHomeScreen() {
   const {
     profile,
     isLoading: profileLoading,
+    hasLoaded: profileHasLoaded,
     reloadProfile,
   } = useUserProfile();
   const { customDocumentTypes } = useDocumentsStore();
 
   const [profileChecked, setProfileChecked] = useState(false);
 
-  // Only redirect to profile-setup after profile has been loaded at least once
+  // Gate on hasLoaded rather than !isLoading — the store starts with
+  // isLoading=false, so checking !isLoading would fire this redirect
+  // before the first load has even begun and wrongly send users who
+  // already have a profile back to the setup screen.
   useEffect(() => {
-    if (profileLoading) return;
+    if (!profileHasLoaded) return;
     if (profileChecked) return;
     setProfileChecked(true);
     if (!profile) {
       router.push("/profile-setup");
     }
-  }, [profile, profileLoading, profileChecked]);
+  }, [profile, profileHasLoaded, profileChecked, router]);
 
   useFocusEffect(
     React.useCallback(() => {

--- a/src/stores/profile.store.ts
+++ b/src/stores/profile.store.ts
@@ -10,6 +10,11 @@ import { SaveUserProfileUseCase } from "@domain/use-cases/save-user-profile.use-
 interface ProfileState {
   profile: UserProfile | null;
   isLoading: boolean;
+  // `hasLoaded` flips to true once loadProfile has resolved at least
+  // once (success OR error). Screens that redirect on a missing profile
+  // (e.g. wallet-home → /profile-setup) must gate on this flag so they
+  // don't fire before the load has even started.
+  hasLoaded: boolean;
   error: string | null;
   loadProfile: () => Promise<void>;
   saveProfile: (
@@ -21,6 +26,7 @@ interface ProfileState {
 export const useProfileStore = create<ProfileState>((set, get) => ({
   profile: null,
   isLoading: false,
+  hasLoaded: false,
   error: null,
 
   loadProfile: async () => {
@@ -30,10 +36,14 @@ export const useProfileStore = create<ProfileState>((set, get) => ({
       const repository = new UserProfileRepositoryImpl();
       const getUserProfileUseCase = new GetUserProfileUseCase(repository);
       const profile = await getUserProfileUseCase.execute();
-      set({ profile, isLoading: false });
+      set({ profile, isLoading: false, hasLoaded: true });
     } catch (error) {
       console.error("Error loading profile:", error);
-      set({ error: "Failed to load profile", isLoading: false });
+      set({
+        error: "Failed to load profile",
+        isLoading: false,
+        hasLoaded: true,
+      });
     }
   },
 
@@ -45,7 +55,11 @@ export const useProfileStore = create<ProfileState>((set, get) => ({
       const result = await saveUserProfileUseCase.execute(input);
 
       if (result.success && result.profile) {
-        set({ profile: result.profile, isLoading: false });
+        set({
+          profile: result.profile,
+          isLoading: false,
+          hasLoaded: true,
+        });
         return { success: true, message: result.message };
       } else {
         set({ error: result.message, isLoading: false });
@@ -60,6 +74,6 @@ export const useProfileStore = create<ProfileState>((set, get) => ({
   },
 
   reset: () => {
-    set({ profile: null, isLoading: false, error: null });
+    set({ profile: null, isLoading: false, hasLoaded: false, error: null });
   },
 }));


### PR DESCRIPTION
## Summary

Bug introduzido no PR #170 (perf). Quando dedupei os loads concorrentes dos stores, troquei o \`isLoading\` inicial de \`profile.store\` de \`true\` pra \`false\` pra deixar o guard \`if (isLoading) return\` funcionar.

Só que o \`wallet-home-screen\` tinha um efeito gated em \`!profileLoading\` pra decidir o redirect pro \`/profile-setup\`:

\`\`\`tsx
useEffect(() => {
  if (profileLoading) return;         // ← agora passa logo no primeiro render
  if (profileChecked) return;
  setProfileChecked(true);
  if (!profile) {                     // ← profile ainda é null porque load não rodou
    router.push(\"/profile-setup\");    // ← manda todo mundo pra setup
  }
}, [profile, profileLoading, profileChecked]);
\`\`\`

Com \`isLoading=false\` inicial, o efeito roda **antes** do \`loadProfile()\` iniciar, vê \`profile=null && !profileLoading\`, e dispara o redirect mesmo pra quem tem perfil salvo.

## Fix

Novo flag **\`hasLoaded\`** no store, que só vira \`true\` depois que \`loadProfile\` resolve (success ou error):

\`\`\`ts
loadProfile: async () => {
  if (get().isLoading) return;
  try {
    set({ isLoading: true, error: null });
    ...
    set({ profile, isLoading: false, hasLoaded: true });
  } catch {
    set({ error: ..., isLoading: false, hasLoaded: true });
  }
}
\`\`\`

No \`wallet-home-screen\` o gate passa a ser \`hasLoaded\`:

\`\`\`tsx
if (!profileHasLoaded) return;  // espera o load terminar antes de decidir
if (profileChecked) return;
...
\`\`\`

O \`isLoading\` continua sendo usado no avatar (spinner no header) — sem mudança visual.

\`reset()\` também zera \`hasLoaded\` pra manter consistência (clearAllData fresh install precisa ver \`hasLoaded=false\` pra que o redirect volte a funcionar quando o usuário for criar um novo perfil).

## Test plan

- [x] \`npm test\` — 837 passando
- [x] \`npx tsc --noEmit\` sem novos erros
- [ ] QA: app com perfil salvo → desbloquear PIN → cai direto em \`/(tabs)\`, não em \`/profile-setup\`
- [ ] QA: app sem perfil (primeiro uso depois do pin-setup) → cai em \`/profile-setup\` (comportamento correto)
- [ ] QA: Settings → Apagar Todos os Dados → re-criar PIN → perfil vazio → setup dispara corretamente