### PR TITLE
feat(documents): capture mask, pinch-to-resize, sharper crops, edit fix

### DIFF
--- a/src/data/repositories/document.repository.impl.test.ts
+++ b/src/data/repositories/document.repository.impl.test.ts
@@ -252,4 +252,75 @@ describe("DocumentRepositoryImpl", () => {
       expect(ImageProcessingService.decryptAndDecode).toHaveBeenCalledTimes(2);
     });
   });
+
+  describe("Save existing document (edit flow)", () => {
+    it("updates the document in-place when input carries an id that exists", async () => {
+      const existing = createMockDocument({
+        id: "doc_existing",
+        createdAt: new Date("2026-01-01"),
+        isAutoLockEnabled: true,
+      });
+      mockStorage.get.mockResolvedValue(JSON.stringify([existing]));
+
+      const result = await repository.save({
+        id: "doc_existing",
+        typeId: "RG",
+        typeName: "RG novo",
+        fields: { fullName: "Ana Mudou" },
+        photos: { front: "newphotouri" },
+      });
+
+      expect(result.id).toBe("doc_existing");
+      expect(result.typeId).toBe("RG");
+      expect(result.fields.fullName).toBe("Ana Mudou");
+      // createdAt is preserved, not replaced
+      expect(result.createdAt.toISOString()).toBe(
+        new Date("2026-01-01").toISOString(),
+      );
+      // isAutoLockEnabled is preserved from the existing record
+      expect(result.isAutoLockEnabled).toBe(true);
+
+      // Storage was called with a single-entry array (no duplicate)
+      const persisted = JSON.parse(
+        (mockStorage.set as jest.Mock).mock.calls[0][1],
+      );
+      expect(persisted.length).toBe(1);
+      expect(persisted[0].id).toBe("doc_existing");
+    });
+
+    it("creates a new record when the id does not match any existing document", async () => {
+      const existing = createMockDocument({ id: "doc_a" });
+      mockStorage.get.mockResolvedValue(JSON.stringify([existing]));
+
+      const result = await repository.save({
+        id: "doc_missing",
+        typeId: "CNH",
+        typeName: "CNH",
+        fields: {},
+        photos: { front: "uri" },
+      });
+
+      // Fell through to the create path, so it got a fresh doc_* id
+      expect(result.id).toMatch(/^doc_\d+$/);
+      expect(result.id).not.toBe("doc_missing");
+
+      const persisted = JSON.parse(
+        (mockStorage.set as jest.Mock).mock.calls[0][1],
+      );
+      expect(persisted.length).toBe(2);
+    });
+
+    it("creates a new record when no id is supplied", async () => {
+      const existing = createMockDocument({ id: "doc_a" });
+      mockStorage.get.mockResolvedValue(JSON.stringify([existing]));
+
+      const result = await repository.save(mockDocumentInput);
+
+      expect(result.id).not.toBe("doc_a");
+      const persisted = JSON.parse(
+        (mockStorage.set as jest.Mock).mock.calls[0][1],
+      );
+      expect(persisted.length).toBe(2);
+    });
+  });
 });

--- a/src/data/repositories/document.repository.impl.ts
+++ b/src/data/repositories/document.repository.impl.ts
@@ -50,24 +50,42 @@ export class DocumentRepositoryImpl implements DocumentRepository {
         }
       }
 
-      const id = `doc_${Date.now()}`;
+      const documents = await this.findAll();
+      const existingIndex = input.id
+        ? documents.findIndex((doc) => doc.id === input.id)
+        : -1;
+      const now = new Date();
 
-      const document: Document = {
-        id,
+      if (existingIndex !== -1) {
+        const existing = documents[existingIndex];
+        const updated: Document = {
+          id: existing.id,
+          typeId: input.typeId,
+          typeName: input.typeName,
+          fields: { ...input.fields },
+          photos: encryptedPhotos,
+          isAutoLockEnabled: existing.isAutoLockEnabled,
+          createdAt: existing.createdAt,
+          updatedAt: now,
+        };
+        documents[existingIndex] = updated;
+        await this.storage.set(this.DOCUMENTS_KEY, JSON.stringify(documents));
+        return updated;
+      }
+
+      const created: Document = {
+        id: `doc_${Date.now()}`,
         typeId: input.typeId,
         typeName: input.typeName,
         fields: { ...input.fields },
         photos: encryptedPhotos,
         isAutoLockEnabled: false,
-        createdAt: new Date(),
-        updatedAt: new Date(),
+        createdAt: now,
+        updatedAt: now,
       };
-
-      const documents = await this.findAll();
-      documents.push(document);
+      documents.push(created);
       await this.storage.set(this.DOCUMENTS_KEY, JSON.stringify(documents));
-
-      return document;
+      return created;
     } catch (error) {
       console.error("Error saving document:", error);
       throw new Error("Failed to save document");

--- a/src/domain/entities/document.entity.ts
+++ b/src/domain/entities/document.entity.ts
@@ -13,6 +13,9 @@ export interface Document {
 }
 
 export interface DocumentInput {
+  // When present, `save` updates the existing document in-place and
+  // preserves `createdAt`. Absent means a new document is created.
+  id?: string;
   typeId: string;
   typeName: string;
   fields: Record<string, string>;

--- a/src/presentation/components/document-camera-modal.tsx
+++ b/src/presentation/components/document-camera-modal.tsx
@@ -1,0 +1,227 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  Modal,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { CameraView, useCameraPermissions } from "expo-camera";
+import * as ImageManipulator from "expo-image-manipulator";
+import { ChevronLeft, RefreshCw } from "lucide-react-native";
+import { useTranslation } from "react-i18next";
+import { tokens } from "@presentation/theme/design-tokens";
+
+interface DocumentCameraModalProps {
+  visible: boolean;
+  onClose: () => void;
+  onCapture: (uri: string) => void;
+}
+
+// ISO/IEC 7810 ID-1 aspect — 85.60 × 54.00 mm (~1.585:1). Covers CNH,
+// RG novo (CIN), CPF, cartão de crédito and most Brazilian IDs in the
+// same frame. Passport is a separate, taller format and intentionally
+// not targeted here.
+const DOCUMENT_ASPECT_RATIO = 85.6 / 54;
+const GUIDE_WIDTH = 320;
+const GUIDE_HEIGHT = Math.round(GUIDE_WIDTH / DOCUMENT_ASPECT_RATIO);
+
+export function DocumentCameraModal({
+  visible,
+  onClose,
+  onCapture,
+}: DocumentCameraModalProps) {
+  const { t } = useTranslation();
+  const [permission, requestPermission] = useCameraPermissions();
+  const cameraRef = useRef<CameraView>(null);
+  const [isCapturing, setIsCapturing] = useState(false);
+  const [facing, setFacing] = useState<"front" | "back">("back");
+
+  useEffect(() => {
+    if (
+      visible &&
+      permission &&
+      !permission.granted &&
+      permission.canAskAgain
+    ) {
+      requestPermission();
+    }
+  }, [visible, permission, requestPermission]);
+
+  const handleCapture = async () => {
+    if (!cameraRef.current || isCapturing) {
+      return;
+    }
+    setIsCapturing(true);
+    try {
+      const photo = await cameraRef.current.takePictureAsync({
+        quality: 0.85,
+        skipProcessing: false,
+      });
+      if (!photo) {
+        return;
+      }
+
+      // Center-crop the photo to the ID-1 aspect ratio the guide shows.
+      // The full frame is captured; the guide is only a visual reference,
+      // so we derive the crop from the photo's actual dimensions.
+      const { width: w, height: h } = photo;
+      let cropWidth: number;
+      let cropHeight: number;
+      if (w / h > DOCUMENT_ASPECT_RATIO) {
+        // Photo is wider than the target — pillar-crop the sides.
+        cropHeight = h;
+        cropWidth = Math.round(h * DOCUMENT_ASPECT_RATIO);
+      } else {
+        // Photo is taller than the target (typical portrait phone capture) —
+        // letter-crop top/bottom.
+        cropWidth = w;
+        cropHeight = Math.round(w / DOCUMENT_ASPECT_RATIO);
+      }
+      const originX = Math.max(0, Math.round((w - cropWidth) / 2));
+      const originY = Math.max(0, Math.round((h - cropHeight) / 2));
+
+      const cropped = await ImageManipulator.manipulateAsync(
+        photo.uri,
+        [
+          {
+            crop: {
+              originX,
+              originY,
+              width: cropWidth,
+              height: cropHeight,
+            },
+          },
+        ],
+        { compress: 0.85, format: ImageManipulator.SaveFormat.JPEG },
+      );
+      onCapture(cropped.uri);
+      onClose();
+    } catch (error) {
+      console.error("Error capturing document photo:", error);
+    } finally {
+      setIsCapturing(false);
+    }
+  };
+
+  const handleFlipFacing = () => {
+    if (isCapturing) return;
+    setFacing((current) => (current === "back" ? "front" : "back"));
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      presentationStyle="overFullScreen"
+      statusBarTranslucent
+      animationType="slide"
+      onRequestClose={onClose}
+    >
+      <View className="flex-1 bg-black">
+        {permission?.granted ? (
+          <CameraView
+            ref={cameraRef}
+            style={StyleSheet.absoluteFill}
+            facing={facing}
+          >
+            <View
+              pointerEvents="none"
+              className="flex-1 items-center justify-center"
+            >
+              <View
+                style={{
+                  width: GUIDE_WIDTH,
+                  height: GUIDE_HEIGHT,
+                  borderRadius: 12,
+                  borderWidth: 3,
+                  borderColor: "rgba(255,255,255,0.9)",
+                  borderStyle: "dashed",
+                }}
+              />
+              <Text className="text-white text-base font-semibold mt-6 mx-8 text-center">
+                {t("addDocument.documentPhotoGuide")}
+              </Text>
+            </View>
+          </CameraView>
+        ) : (
+          <View className="flex-1 items-center justify-center px-8">
+            <Text className="text-white text-center mb-4 text-base">
+              {permission === null
+                ? t("common.loading")
+                : t("addDocument.cameraPermissionMsg")}
+            </Text>
+            {permission && !permission.granted && permission.canAskAgain && (
+              <Pressable
+                accessibilityRole="button"
+                onPress={requestPermission}
+                className="bg-primary-main px-6 py-3 rounded-xl"
+              >
+                <Text className="text-white font-semibold">
+                  {t("common.continue")}
+                </Text>
+              </Pressable>
+            )}
+          </View>
+        )}
+
+        <SafeAreaView
+          edges={["top"]}
+          pointerEvents="box-none"
+          className="absolute top-0 left-0 right-0"
+        >
+          <View className="flex-row justify-between items-center px-4 py-2">
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={t("common.close")}
+              className="w-10 h-10 items-center justify-center bg-black/50 rounded-full"
+              onPress={onClose}
+            >
+              <ChevronLeft color="white" size={24} />
+            </Pressable>
+            {permission?.granted && (
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={t("profile.flipCamera")}
+                className="w-10 h-10 items-center justify-center bg-black/50 rounded-full"
+                onPress={handleFlipFacing}
+              >
+                <RefreshCw color="white" size={20} />
+              </Pressable>
+            )}
+          </View>
+        </SafeAreaView>
+
+        <SafeAreaView
+          edges={["bottom"]}
+          pointerEvents="box-none"
+          className="absolute bottom-0 left-0 right-0"
+        >
+          <View className="items-center pb-8">
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={t("addDocument.capturePhoto")}
+              accessibilityState={{ disabled: isCapturing }}
+              disabled={isCapturing || !permission?.granted}
+              onPress={handleCapture}
+              className="w-20 h-20 rounded-full items-center justify-center"
+              style={{
+                backgroundColor: "rgba(255,255,255,0.25)",
+                borderWidth: 4,
+                borderColor: "white",
+              }}
+            >
+              {isCapturing ? (
+                <ActivityIndicator color={tokens.colors.text.primary} />
+              ) : (
+                <View className="w-14 h-14 rounded-full bg-white" />
+              )}
+            </Pressable>
+          </View>
+        </SafeAreaView>
+      </View>
+    </Modal>
+  );
+}

--- a/src/presentation/components/document-camera-modal.tsx
+++ b/src/presentation/components/document-camera-modal.tsx
@@ -9,6 +9,15 @@ import {
   View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import {
+  Gesture,
+  GestureDetector,
+  GestureHandlerRootView,
+} from "react-native-gesture-handler";
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+} from "react-native-reanimated";
 import { CameraView, useCameraPermissions } from "expo-camera";
 import * as ImageManipulator from "expo-image-manipulator";
 import { ChevronLeft, RefreshCw } from "lucide-react-native";
@@ -31,6 +40,9 @@ const GUIDE_HORIZONTAL_MARGIN = 16;
 // Cap for tablets — above ~480 the guide dominates the viewfinder and
 // hurts framing on large portrait screens.
 const GUIDE_MAX_WIDTH = 480;
+// Absolute pinch bounds so the user can't shrink the guide into
+// invisibility or blow it past the edge of the camera preview.
+const GUIDE_MIN_PT = 200;
 
 export function DocumentCameraModal({
   visible,
@@ -44,11 +56,43 @@ export function DocumentCameraModal({
   const [isCapturing, setIsCapturing] = useState(false);
   const [facing, setFacing] = useState<"front" | "back">("back");
 
-  const guideWidth = Math.min(
+  const baseWidth = Math.min(
     screenWidth - GUIDE_HORIZONTAL_MARGIN * 2,
     GUIDE_MAX_WIDTH,
   );
-  const guideHeight = Math.round(guideWidth / DOCUMENT_ASPECT_RATIO);
+  const minScale = GUIDE_MIN_PT / baseWidth;
+  const maxScale = (screenWidth - GUIDE_HORIZONTAL_MARGIN) / baseWidth;
+
+  const scale = useSharedValue(1);
+  const savedScale = useSharedValue(1);
+
+  const pinchGesture = Gesture.Pinch()
+    .onUpdate((event) => {
+      const next = savedScale.value * event.scale;
+      scale.value =
+        next < minScale ? minScale : next > maxScale ? maxScale : next;
+    })
+    .onEnd(() => {
+      savedScale.value = scale.value;
+    });
+
+  const animatedGuideStyle = useAnimatedStyle(() => {
+    const width = baseWidth * scale.value;
+    return {
+      width,
+      height: width / DOCUMENT_ASPECT_RATIO,
+    };
+  });
+
+  // Reset the guide size whenever the modal is reopened so a new
+  // capture session doesn't inherit the previous zoom.
+  useEffect(() => {
+    if (visible) {
+      scale.value = 1;
+      savedScale.value = 1;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visible]);
 
   useEffect(() => {
     if (
@@ -68,9 +112,6 @@ export function DocumentCameraModal({
     setIsCapturing(true);
     try {
       const photo = await cameraRef.current.takePictureAsync({
-        // Max-fidelity capture. The ImageManipulator pass below still
-        // re-encodes at 0.9 JPEG so storage stays bounded, but the crop
-        // is taken from the highest-resolution source the sensor gives.
         quality: 1,
         skipProcessing: false,
       });
@@ -78,9 +119,12 @@ export function DocumentCameraModal({
         return;
       }
 
-      // Map the on-screen guide rectangle into the captured photo so we
-      // save exactly what the user framed inside the dashed outline.
-      //
+      // Read the current pinch-adjusted guide size so the crop follows
+      // whatever the user framed at capture time.
+      const currentScale = scale.value;
+      const currentGuideWidth = baseWidth * currentScale;
+      const currentGuideHeight = currentGuideWidth / DOCUMENT_ASPECT_RATIO;
+
       // CameraView renders in "cover" mode: the photo is scaled so its
       // smallest dimension matches the screen, and the overflow on the
       // other axis is cropped from the preview. We derive the scale
@@ -91,8 +135,10 @@ export function DocumentCameraModal({
       const screenAspect = screenWidth / screenHeight;
       const photoPxPerScreenPx =
         photoAspect > screenAspect ? h / screenHeight : w / screenWidth;
-      const guidePhotoWidth = Math.round(guideWidth * photoPxPerScreenPx);
-      const guidePhotoHeight = Math.round(guideHeight * photoPxPerScreenPx);
+      const guidePhotoWidth = Math.round(currentGuideWidth * photoPxPerScreenPx);
+      const guidePhotoHeight = Math.round(
+        currentGuideHeight * photoPxPerScreenPx,
+      );
       const originX = Math.max(0, Math.round((w - guidePhotoWidth) / 2));
       const originY = Math.max(0, Math.round((h - guidePhotoHeight) / 2));
       const cropWidth = Math.min(w - originX, guidePhotoWidth);
@@ -135,112 +181,120 @@ export function DocumentCameraModal({
       animationType="slide"
       onRequestClose={onClose}
     >
-      <View className="flex-1 bg-black">
-        {permission?.granted ? (
-          <CameraView
-            ref={cameraRef}
-            style={StyleSheet.absoluteFill}
-            facing={facing}
-            autofocus="on"
-          >
-            <View
-              pointerEvents="none"
-              className="flex-1 items-center justify-center"
+      <GestureHandlerRootView style={{ flex: 1 }}>
+        <View className="flex-1 bg-black">
+          {permission?.granted ? (
+            <CameraView
+              ref={cameraRef}
+              style={StyleSheet.absoluteFill}
+              facing={facing}
+              autofocus="on"
             >
-              <View
-                style={{
-                  width: guideWidth,
-                  height: guideHeight,
-                  borderRadius: 12,
-                  borderWidth: 3,
-                  borderColor: "rgba(255,255,255,0.9)",
-                  borderStyle: "dashed",
-                }}
-              />
-              <Text className="text-white text-base font-semibold mt-6 mx-8 text-center">
-                {t("addDocument.documentPhotoGuide")}
+              <GestureDetector gesture={pinchGesture}>
+                <View className="flex-1 items-center justify-center">
+                  <Animated.View
+                    style={[
+                      animatedGuideStyle,
+                      {
+                        borderRadius: 12,
+                        borderWidth: 3,
+                        borderColor: "rgba(255,255,255,0.9)",
+                        borderStyle: "dashed",
+                      },
+                    ]}
+                  />
+                  <Text
+                    pointerEvents="none"
+                    className="text-white text-base font-semibold mt-6 mx-8 text-center"
+                  >
+                    {t("addDocument.documentPhotoGuide")}
+                  </Text>
+                  <Text
+                    pointerEvents="none"
+                    className="text-white/80 text-sm mt-2 mx-8 text-center"
+                  >
+                    {t("addDocument.documentPhotoHint")}
+                  </Text>
+                </View>
+              </GestureDetector>
+            </CameraView>
+          ) : (
+            <View className="flex-1 items-center justify-center px-8">
+              <Text className="text-white text-center mb-4 text-base">
+                {permission === null
+                  ? t("common.loading")
+                  : t("addDocument.cameraPermissionMsg")}
               </Text>
-              <Text className="text-white/80 text-sm mt-2 mx-8 text-center">
-                {t("addDocument.documentPhotoHint")}
-              </Text>
-            </View>
-          </CameraView>
-        ) : (
-          <View className="flex-1 items-center justify-center px-8">
-            <Text className="text-white text-center mb-4 text-base">
-              {permission === null
-                ? t("common.loading")
-                : t("addDocument.cameraPermissionMsg")}
-            </Text>
-            {permission && !permission.granted && permission.canAskAgain && (
-              <Pressable
-                accessibilityRole="button"
-                onPress={requestPermission}
-                className="bg-primary-main px-6 py-3 rounded-xl"
-              >
-                <Text className="text-white font-semibold">
-                  {t("common.continue")}
-                </Text>
-              </Pressable>
-            )}
-          </View>
-        )}
-
-        <SafeAreaView
-          edges={["top"]}
-          pointerEvents="box-none"
-          className="absolute top-0 left-0 right-0"
-        >
-          <View className="flex-row justify-between items-center px-4 py-2">
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel={t("common.close")}
-              className="w-10 h-10 items-center justify-center bg-black/50 rounded-full"
-              onPress={onClose}
-            >
-              <ChevronLeft color="white" size={24} />
-            </Pressable>
-            {permission?.granted && (
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel={t("profile.flipCamera")}
-                className="w-10 h-10 items-center justify-center bg-black/50 rounded-full"
-                onPress={handleFlipFacing}
-              >
-                <RefreshCw color="white" size={20} />
-              </Pressable>
-            )}
-          </View>
-        </SafeAreaView>
-
-        <SafeAreaView
-          edges={["bottom"]}
-          pointerEvents="box-none"
-          className="absolute bottom-0 left-0 right-0"
-        >
-          <View className="items-center pb-8">
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel={t("addDocument.capturePhoto")}
-              accessibilityState={{ disabled: isCapturing }}
-              disabled={isCapturing || !permission?.granted}
-              onPress={handleCapture}
-              className="w-20 h-20 rounded-full items-center justify-center"
-              style={{
-                backgroundColor: "rgba(255,255,255,0.25)",
-                borderWidth: 4,
-                borderColor: "white",
-              }}
-            >
-              {isCapturing ? (
-                <ActivityIndicator color={tokens.colors.text.primary} />
-              ) : (
-                <View className="w-14 h-14 rounded-full bg-white" />
+              {permission && !permission.granted && permission.canAskAgain && (
+                <Pressable
+                  accessibilityRole="button"
+                  onPress={requestPermission}
+                  className="bg-primary-main px-6 py-3 rounded-xl"
+                >
+                  <Text className="text-white font-semibold">
+                    {t("common.continue")}
+                  </Text>
+                </Pressable>
               )}
-            </Pressable>
-          </View>
-        </SafeAreaView>
-      </View>
+            </View>
+          )}
+
+          <SafeAreaView
+            edges={["top"]}
+            pointerEvents="box-none"
+            className="absolute top-0 left-0 right-0"
+          >
+            <View className="flex-row justify-between items-center px-4 py-2">
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={t("common.close")}
+                className="w-10 h-10 items-center justify-center bg-black/50 rounded-full"
+                onPress={onClose}
+              >
+                <ChevronLeft color="white" size={24} />
+              </Pressable>
+              {permission?.granted && (
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={t("profile.flipCamera")}
+                  className="w-10 h-10 items-center justify-center bg-black/50 rounded-full"
+                  onPress={handleFlipFacing}
+                >
+                  <RefreshCw color="white" size={20} />
+                </Pressable>
+              )}
+            </View>
+          </SafeAreaView>
+
+          <SafeAreaView
+            edges={["bottom"]}
+            pointerEvents="box-none"
+            className="absolute bottom-0 left-0 right-0"
+          >
+            <View className="items-center pb-8">
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={t("addDocument.capturePhoto")}
+                accessibilityState={{ disabled: isCapturing }}
+                disabled={isCapturing || !permission?.granted}
+                onPress={handleCapture}
+                className="w-20 h-20 rounded-full items-center justify-center"
+                style={{
+                  backgroundColor: "rgba(255,255,255,0.25)",
+                  borderWidth: 4,
+                  borderColor: "white",
+                }}
+              >
+                {isCapturing ? (
+                  <ActivityIndicator color={tokens.colors.text.primary} />
+                ) : (
+                  <View className="w-14 h-14 rounded-full bg-white" />
+                )}
+              </Pressable>
+            </View>
+          </SafeAreaView>
+        </View>
+      </GestureHandlerRootView>
     </Modal>
   );
 }

--- a/src/presentation/components/document-camera-modal.tsx
+++ b/src/presentation/components/document-camera-modal.tsx
@@ -5,6 +5,7 @@ import {
   Pressable,
   StyleSheet,
   Text,
+  useWindowDimensions,
   View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -25,7 +26,7 @@ interface DocumentCameraModalProps {
 // same frame. Passport is a separate, taller format and intentionally
 // not targeted here.
 const DOCUMENT_ASPECT_RATIO = 85.6 / 54;
-const GUIDE_WIDTH = 320;
+const GUIDE_WIDTH = 360;
 const GUIDE_HEIGHT = Math.round(GUIDE_WIDTH / DOCUMENT_ASPECT_RATIO);
 
 export function DocumentCameraModal({
@@ -34,6 +35,7 @@ export function DocumentCameraModal({
   onCapture,
 }: DocumentCameraModalProps) {
   const { t } = useTranslation();
+  const { width: screenWidth, height: screenHeight } = useWindowDimensions();
   const [permission, requestPermission] = useCameraPermissions();
   const cameraRef = useRef<CameraView>(null);
   const [isCapturing, setIsCapturing] = useState(false);
@@ -64,24 +66,25 @@ export function DocumentCameraModal({
         return;
       }
 
-      // Center-crop the photo to the ID-1 aspect ratio the guide shows.
-      // The full frame is captured; the guide is only a visual reference,
-      // so we derive the crop from the photo's actual dimensions.
+      // Map the on-screen guide rectangle into the captured photo so we
+      // save exactly what the user framed inside the dashed outline.
+      //
+      // CameraView renders in "cover" mode: the photo is scaled so its
+      // smallest dimension matches the screen, and the overflow on the
+      // other axis is cropped from the preview. We derive the scale
+      // factor from whichever axis is filling the screen, then express
+      // the guide's on-screen size in photo pixels.
       const { width: w, height: h } = photo;
-      let cropWidth: number;
-      let cropHeight: number;
-      if (w / h > DOCUMENT_ASPECT_RATIO) {
-        // Photo is wider than the target — pillar-crop the sides.
-        cropHeight = h;
-        cropWidth = Math.round(h * DOCUMENT_ASPECT_RATIO);
-      } else {
-        // Photo is taller than the target (typical portrait phone capture) —
-        // letter-crop top/bottom.
-        cropWidth = w;
-        cropHeight = Math.round(w / DOCUMENT_ASPECT_RATIO);
-      }
-      const originX = Math.max(0, Math.round((w - cropWidth) / 2));
-      const originY = Math.max(0, Math.round((h - cropHeight) / 2));
+      const photoAspect = w / h;
+      const screenAspect = screenWidth / screenHeight;
+      const photoPxPerScreenPx =
+        photoAspect > screenAspect ? h / screenHeight : w / screenWidth;
+      const guidePhotoWidth = Math.round(GUIDE_WIDTH * photoPxPerScreenPx);
+      const guidePhotoHeight = Math.round(GUIDE_HEIGHT * photoPxPerScreenPx);
+      const originX = Math.max(0, Math.round((w - guidePhotoWidth) / 2));
+      const originY = Math.max(0, Math.round((h - guidePhotoHeight) / 2));
+      const cropWidth = Math.min(w - originX, guidePhotoWidth);
+      const cropHeight = Math.min(h - originY, guidePhotoHeight);
 
       const cropped = await ImageManipulator.manipulateAsync(
         photo.uri,

--- a/src/presentation/components/document-camera-modal.tsx
+++ b/src/presentation/components/document-camera-modal.tsx
@@ -43,6 +43,11 @@ const GUIDE_MAX_WIDTH = 480;
 // Absolute pinch bounds so the user can't shrink the guide into
 // invisibility or blow it past the edge of the camera preview.
 const GUIDE_MIN_PT = 200;
+// Extra padding in photo pixels on each side of the crop. Compensates
+// for the dashed border width, sub-pixel rounding, and the preview's
+// small layout differences between devices — without it, users were
+// losing a sliver of content at the edges of the framed area.
+const CROP_BUFFER_RATIO = 0.03;
 
 export function DocumentCameraModal({
   visible,
@@ -135,14 +140,16 @@ export function DocumentCameraModal({
       const screenAspect = screenWidth / screenHeight;
       const photoPxPerScreenPx =
         photoAspect > screenAspect ? h / screenHeight : w / screenWidth;
-      const guidePhotoWidth = Math.round(currentGuideWidth * photoPxPerScreenPx);
-      const guidePhotoHeight = Math.round(
-        currentGuideHeight * photoPxPerScreenPx,
-      );
-      const originX = Math.max(0, Math.round((w - guidePhotoWidth) / 2));
-      const originY = Math.max(0, Math.round((h - guidePhotoHeight) / 2));
-      const cropWidth = Math.min(w - originX, guidePhotoWidth);
-      const cropHeight = Math.min(h - originY, guidePhotoHeight);
+      const guidePhotoWidth = currentGuideWidth * photoPxPerScreenPx;
+      const guidePhotoHeight = currentGuideHeight * photoPxPerScreenPx;
+      // Grow the crop proportionally on both axes so the aspect ratio
+      // stays 1.585:1 and the dashed border area is fully included.
+      const bufferedWidth = guidePhotoWidth * (1 + CROP_BUFFER_RATIO * 2);
+      const bufferedHeight = guidePhotoHeight * (1 + CROP_BUFFER_RATIO * 2);
+      const originX = Math.max(0, Math.round((w - bufferedWidth) / 2));
+      const originY = Math.max(0, Math.round((h - bufferedHeight) / 2));
+      const cropWidth = Math.min(w - originX, Math.round(bufferedWidth));
+      const cropHeight = Math.min(h - originY, Math.round(bufferedHeight));
 
       const cropped = await ImageManipulator.manipulateAsync(
         photo.uri,

--- a/src/presentation/components/document-camera-modal.tsx
+++ b/src/presentation/components/document-camera-modal.tsx
@@ -26,8 +26,11 @@ interface DocumentCameraModalProps {
 // same frame. Passport is a separate, taller format and intentionally
 // not targeted here.
 const DOCUMENT_ASPECT_RATIO = 85.6 / 54;
-const GUIDE_WIDTH = 360;
-const GUIDE_HEIGHT = Math.round(GUIDE_WIDTH / DOCUMENT_ASPECT_RATIO);
+// Side margin so the dashed outline isn't flush against the edges.
+const GUIDE_HORIZONTAL_MARGIN = 16;
+// Cap for tablets — above ~480 the guide dominates the viewfinder and
+// hurts framing on large portrait screens.
+const GUIDE_MAX_WIDTH = 480;
 
 export function DocumentCameraModal({
   visible,
@@ -40,6 +43,12 @@ export function DocumentCameraModal({
   const cameraRef = useRef<CameraView>(null);
   const [isCapturing, setIsCapturing] = useState(false);
   const [facing, setFacing] = useState<"front" | "back">("back");
+
+  const guideWidth = Math.min(
+    screenWidth - GUIDE_HORIZONTAL_MARGIN * 2,
+    GUIDE_MAX_WIDTH,
+  );
+  const guideHeight = Math.round(guideWidth / DOCUMENT_ASPECT_RATIO);
 
   useEffect(() => {
     if (
@@ -59,7 +68,10 @@ export function DocumentCameraModal({
     setIsCapturing(true);
     try {
       const photo = await cameraRef.current.takePictureAsync({
-        quality: 0.85,
+        // Max-fidelity capture. The ImageManipulator pass below still
+        // re-encodes at 0.9 JPEG so storage stays bounded, but the crop
+        // is taken from the highest-resolution source the sensor gives.
+        quality: 1,
         skipProcessing: false,
       });
       if (!photo) {
@@ -79,8 +91,8 @@ export function DocumentCameraModal({
       const screenAspect = screenWidth / screenHeight;
       const photoPxPerScreenPx =
         photoAspect > screenAspect ? h / screenHeight : w / screenWidth;
-      const guidePhotoWidth = Math.round(GUIDE_WIDTH * photoPxPerScreenPx);
-      const guidePhotoHeight = Math.round(GUIDE_HEIGHT * photoPxPerScreenPx);
+      const guidePhotoWidth = Math.round(guideWidth * photoPxPerScreenPx);
+      const guidePhotoHeight = Math.round(guideHeight * photoPxPerScreenPx);
       const originX = Math.max(0, Math.round((w - guidePhotoWidth) / 2));
       const originY = Math.max(0, Math.round((h - guidePhotoHeight) / 2));
       const cropWidth = Math.min(w - originX, guidePhotoWidth);
@@ -98,7 +110,7 @@ export function DocumentCameraModal({
             },
           },
         ],
-        { compress: 0.85, format: ImageManipulator.SaveFormat.JPEG },
+        { compress: 0.9, format: ImageManipulator.SaveFormat.JPEG },
       );
       onCapture(cropped.uri);
       onClose();
@@ -129,6 +141,7 @@ export function DocumentCameraModal({
             ref={cameraRef}
             style={StyleSheet.absoluteFill}
             facing={facing}
+            autofocus="on"
           >
             <View
               pointerEvents="none"
@@ -136,8 +149,8 @@ export function DocumentCameraModal({
             >
               <View
                 style={{
-                  width: GUIDE_WIDTH,
-                  height: GUIDE_HEIGHT,
+                  width: guideWidth,
+                  height: guideHeight,
                   borderRadius: 12,
                   borderWidth: 3,
                   borderColor: "rgba(255,255,255,0.9)",
@@ -146,6 +159,9 @@ export function DocumentCameraModal({
               />
               <Text className="text-white text-base font-semibold mt-6 mx-8 text-center">
                 {t("addDocument.documentPhotoGuide")}
+              </Text>
+              <Text className="text-white/80 text-sm mt-2 mx-8 text-center">
+                {t("addDocument.documentPhotoHint")}
               </Text>
             </View>
           </CameraView>

--- a/src/presentation/components/document-photo-carousel.tsx
+++ b/src/presentation/components/document-photo-carousel.tsx
@@ -2,6 +2,7 @@ import {
   View,
   ScrollView,
   Image,
+  Pressable,
   Dimensions,
   NativeScrollEvent,
   NativeSyntheticEvent,
@@ -11,11 +12,13 @@ import { useState } from "react";
 interface DocumentPhotoCarouselProps {
   frontPhotoUri: string;
   backPhotoUri: string;
+  onPhotoPress?: (uri: string) => void;
 }
 
 export function DocumentPhotoCarousel({
   frontPhotoUri,
   backPhotoUri,
+  onPhotoPress,
 }: DocumentPhotoCarouselProps) {
   const [currentIndex, setCurrentIndex] = useState(0);
   const screenWidth = Dimensions.get("window").width;
@@ -40,22 +43,34 @@ export function DocumentPhotoCarousel({
           paddingHorizontal: 24,
         }}
       >
-        <View style={{ width: photoWidth, marginRight: 16 }}>
+        <Pressable
+          style={{ width: photoWidth, marginRight: 16 }}
+          onPress={
+            onPhotoPress ? () => onPhotoPress(frontPhotoUri) : undefined
+          }
+          accessibilityRole={onPhotoPress ? "button" : undefined}
+        >
           <Image
             source={{ uri: frontPhotoUri }}
             className="w-full rounded-2xl bg-light-bgSecondary dark:bg-background-secondary"
             style={{ aspectRatio: 4 / 3 }}
             resizeMode="cover"
           />
-        </View>
-        <View style={{ width: photoWidth }}>
+        </Pressable>
+        <Pressable
+          style={{ width: photoWidth }}
+          onPress={
+            onPhotoPress ? () => onPhotoPress(backPhotoUri) : undefined
+          }
+          accessibilityRole={onPhotoPress ? "button" : undefined}
+        >
           <Image
             source={{ uri: backPhotoUri }}
             className="w-full rounded-2xl bg-light-bgSecondary dark:bg-background-secondary"
             style={{ aspectRatio: 4 / 3 }}
             resizeMode="cover"
           />
-        </View>
+        </Pressable>
       </ScrollView>
 
       <View className="flex-row justify-center gap-2 mt-4">

--- a/src/presentation/screens/add-document-screen.tsx
+++ b/src/presentation/screens/add-document-screen.tsx
@@ -2,9 +2,9 @@ import { View, Text, ScrollView, Pressable, Alert } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { DropdownInput } from "@presentation/components/dropdown-input";
 import { DynamicDocumentForm } from "@presentation/components/dynamic-document-form";
+import { DocumentCameraModal } from "@presentation/components/document-camera-modal";
 import { useRouter, useLocalSearchParams } from "expo-router";
 import { useState, useEffect, useMemo } from "react";
-import * as ImagePicker from "expo-image-picker";
 import { DocumentRepositoryImpl } from "@data/repositories/document.repository.impl";
 import { SaveDocumentUseCase } from "@domain/use-cases/save-document.use-case";
 import { DeleteDocumentUseCase } from "@domain/use-cases/delete-document.use-case";
@@ -49,6 +49,7 @@ export function AddDocumentScreen() {
   const [photos, setPhotos] = useState<Record<string, string>>({});
   const [isLoading, setIsLoading] = useState(false);
   const [isEditMode, setIsEditMode] = useState(false);
+  const [cameraSlot, setCameraSlot] = useState<string | null>(null);
 
   const typeDefinition: DocumentTypeDefinition | undefined = useMemo(
     () => getDocumentTypeById(selectedTypeId, customDocumentTypes),
@@ -100,31 +101,13 @@ export function AddDocumentScreen() {
     setFields((prev) => ({ ...prev, [key]: value }));
   };
 
-  const handleTakePhoto = async (slot: string) => {
-    const { status } = await ImagePicker.requestCameraPermissionsAsync();
-    if (status !== "granted") {
-      Alert.alert(
-        t("addDocument.cameraPermission"),
-        t("addDocument.cameraPermissionMsg"),
-      );
-      return;
-    }
+  const handleTakePhoto = (slot: string) => {
+    setCameraSlot(slot);
+  };
 
-    try {
-      const result = await ImagePicker.launchCameraAsync({
-        mediaTypes: "images",
-        allowsEditing: true,
-        aspect: [4, 3],
-        quality: 0.8,
-      });
-
-      if (!result.canceled && result.assets[0]) {
-        setPhotos((prev) => ({ ...prev, [slot]: result.assets[0].uri }));
-      }
-    } catch (error) {
-      console.error("Error taking photo:", error);
-      Alert.alert(t("common.error"), t("addDocument.photoError"));
-    }
+  const handlePhotoCaptured = (uri: string) => {
+    if (!cameraSlot) return;
+    setPhotos((prev) => ({ ...prev, [cameraSlot]: uri }));
   };
 
   const handleDeleteDocument = async () => {
@@ -274,6 +257,12 @@ export function AddDocumentScreen() {
           </Pressable>
         </ScrollView>
       </View>
+
+      <DocumentCameraModal
+        visible={cameraSlot !== null}
+        onClose={() => setCameraSlot(null)}
+        onCapture={handlePhotoCaptured}
+      />
     </SafeAreaView>
   );
 }

--- a/src/presentation/screens/add-document-screen.tsx
+++ b/src/presentation/screens/add-document-screen.tsx
@@ -142,6 +142,7 @@ export function AddDocumentScreen() {
 
       const result = await useCase.execute(
         {
+          id: isEditMode ? documentId : undefined,
           typeId: selectedTypeId,
           typeName: typeDefinition.label,
           fields,

--- a/src/presentation/screens/document-details-screen.tsx
+++ b/src/presentation/screens/document-details-screen.tsx
@@ -170,20 +170,15 @@ export function DocumentDetailsScreen() {
 
         <ScrollView className="flex-1" showsVerticalScrollIndicator={false}>
           <View className="py-6">
-            {/* Photos — tap to view fullscreen */}
+            {/* Photos — tap on a specific slide opens that photo fullscreen */}
             {photoSlots.length >= 2 &&
               photoUris[photoSlots[0]] &&
               photoUris[photoSlots[1]] && (
-                <View>
-                  <Pressable
-                    onPress={() => setFullscreenPhoto(photoUris[photoSlots[0]])}
-                  >
-                    <DocumentPhotoCarousel
-                      frontPhotoUri={photoUris[photoSlots[0]]}
-                      backPhotoUri={photoUris[photoSlots[1]]}
-                    />
-                  </Pressable>
-                </View>
+                <DocumentPhotoCarousel
+                  frontPhotoUri={photoUris[photoSlots[0]]}
+                  backPhotoUri={photoUris[photoSlots[1]]}
+                  onPhotoPress={(uri) => setFullscreenPhoto(uri)}
+                />
               )}
             {photoSlots.length === 1 && photoUris[photoSlots[0]] && (
               <Pressable

--- a/src/shared/i18n/locales/en-US.json
+++ b/src/shared/i18n/locales/en-US.json
@@ -69,7 +69,7 @@
     "savedSuccess": "Document saved securely",
     "capturePhoto": "Take Photo",
     "documentPhotoGuide": "Align the document inside the rectangle",
-    "documentPhotoHint": "Fill the frame, good lighting, hold the phone steady"
+    "documentPhotoHint": "Pinch to resize the frame to your document"
   },
   "documentDetails": {
     "title": "Document Details",

--- a/src/shared/i18n/locales/en-US.json
+++ b/src/shared/i18n/locales/en-US.json
@@ -68,7 +68,8 @@
     "deleteError": "Failed to delete document",
     "savedSuccess": "Document saved securely",
     "capturePhoto": "Take Photo",
-    "documentPhotoGuide": "Align the document inside the rectangle"
+    "documentPhotoGuide": "Align the document inside the rectangle",
+    "documentPhotoHint": "Fill the frame, good lighting, hold the phone steady"
   },
   "documentDetails": {
     "title": "Document Details",

--- a/src/shared/i18n/locales/en-US.json
+++ b/src/shared/i18n/locales/en-US.json
@@ -66,7 +66,9 @@
     "loadError": "Failed to load document",
     "saveError": "Failed to save document",
     "deleteError": "Failed to delete document",
-    "savedSuccess": "Document saved securely"
+    "savedSuccess": "Document saved securely",
+    "capturePhoto": "Take Photo",
+    "documentPhotoGuide": "Align the document inside the rectangle"
   },
   "documentDetails": {
     "title": "Document Details",

--- a/src/shared/i18n/locales/pt-BR.json
+++ b/src/shared/i18n/locales/pt-BR.json
@@ -66,7 +66,9 @@
     "loadError": "Não foi possível carregar o documento",
     "saveError": "Não foi possível salvar o documento",
     "deleteError": "Não foi possível excluir o documento",
-    "savedSuccess": "Documento salvo com segurança"
+    "savedSuccess": "Documento salvo com segurança",
+    "capturePhoto": "Tirar Foto",
+    "documentPhotoGuide": "Alinhe o documento dentro do retângulo"
   },
   "documentDetails": {
     "title": "Detalhes do Documento",

--- a/src/shared/i18n/locales/pt-BR.json
+++ b/src/shared/i18n/locales/pt-BR.json
@@ -69,7 +69,7 @@
     "savedSuccess": "Documento salvo com segurança",
     "capturePhoto": "Tirar Foto",
     "documentPhotoGuide": "Alinhe o documento dentro do retângulo",
-    "documentPhotoHint": "Preencha o quadro, boa iluminação e celular firme"
+    "documentPhotoHint": "Pince para ajustar o quadro ao tamanho do documento"
   },
   "documentDetails": {
     "title": "Detalhes do Documento",

--- a/src/shared/i18n/locales/pt-BR.json
+++ b/src/shared/i18n/locales/pt-BR.json
@@ -68,7 +68,8 @@
     "deleteError": "Não foi possível excluir o documento",
     "savedSuccess": "Documento salvo com segurança",
     "capturePhoto": "Tirar Foto",
-    "documentPhotoGuide": "Alinhe o documento dentro do retângulo"
+    "documentPhotoGuide": "Alinhe o documento dentro do retângulo",
+    "documentPhotoHint": "Preencha o quadro, boa iluminação e celular firme"
   },
   "documentDetails": {
     "title": "Detalhes do Documento",


### PR DESCRIPTION
## Summary

Pacote consolidado de melhorias no fluxo de documentos. Começou como máscara de alinhamento e cresceu conforme o QA iterou.

### 1. Máscara universal ID-1 com pinch-to-resize

- **Novo \`DocumentCameraModal\`** (\`expo-camera\`, mesma base do \`ProfilePhotoCameraModal\`): câmera traseira default, guia retangular dashed, close + flip + shutter
- **Formato universal ISO/IEC 7810 ID-1** (85.6 × 54 mm, ~1.585:1) cobre CNH, RG novo (CIN), CPF, cartão de crédito e a maioria dos documentos BR com um template só
- **Pinch-to-resize** (\`react-native-gesture-handler\` + \`react-native-reanimated\`): dois dedos redimensionam o pontilhado preservando aspect, clampeado entre 200 pt e \`screenWidth - 16\`. Reset automático a cada abertura do modal.
- **Responsive**: guide = min(screenWidth - 32, 480) com reset a cada reabertura

### 2. Captura nítida

- **\`autofocus=\"on\"\`** explícito — sem isso, a CameraView prendia num plano aleatório e o doc ficava borrado
- **Quality 1.0** na captura + re-encode 0.9 no crop — evita dupla compressão JPEG que serrilhava bordas de texto
- **Hint secundário** abaixo do caption: \"Pince para ajustar o quadro ao tamanho do documento\"

### 3. Crop ancorado no que está dentro do pontilhado

- Mapeia o retângulo da tela pras coordenadas da foto usando o modo cover da CameraView
- **Buffer proporcional de 3% em cada eixo** — compensa a largura da borda tracejada, rounding sub-pixel e diferenças de layout entre devices. Sem o buffer, usuários perdiam um sliver nas bordas do enquadramento.

### 4. Fix: editar documento estava duplicando registro

- \`DocumentInput\` ganha \`id?: string\`
- \`DocumentRepositoryImpl.save\` vira upsert: com id que bate → substitui in-place preservando \`createdAt\` e \`isAutoLockEnabled\`; sem id ou id órfão → cria novo
- \`add-document-screen\` passa \`documentId\` em edit mode
- 3 novos tests cobrindo id+match / id+no-match / no-id

### 5. Fix: carrossel de fotos sempre abria a primeira

- \`DocumentPhotoCarousel\` ganha \`onPhotoPress?: (uri) => void\`; cada slide vira seu próprio \`Pressable\` que passa a própria URI
- Details screen remove o wrapper \`Pressable\` externo e liga \`setFullscreenPhoto\` direto no callback

## Test plan

- [x] \`npm test\` — 840 passando
- [x] \`npx tsc --noEmit\` sem novos erros
- [ ] QA: Add Document → escolher tipo → tocar em slot → modal abre com guia → pinçar → capturar → imagem cropada segue o tamanho escolhido
- [ ] QA: doc grande (A4 photocopy) vs pequeno (CPF) — pinch resolve os dois sem precisar afastar o celular
- [ ] QA: editar documento existente + alterar foto → Save → home mostra só 1 registro, atualizado
- [ ] QA: doc com 2 fotos → details → swipe pra trás → tocar → abre a foto de trás (não a da frente)
- [ ] QA: enquadrar doc com margem zero no pontilhado → nenhuma borda do doc sai cortada no arquivo salvo