### PR TITLE
fix(documents): edit flow updates in place instead of duplicating

### DIFF
--- a/src/data/repositories/document.repository.impl.test.ts
+++ b/src/data/repositories/document.repository.impl.test.ts
@@ -252,4 +252,75 @@ describe("DocumentRepositoryImpl", () => {
       expect(ImageProcessingService.decryptAndDecode).toHaveBeenCalledTimes(2);
     });
   });
+
+  describe("Save existing document (edit flow)", () => {
+    it("updates the document in-place when input carries an id that exists", async () => {
+      const existing = createMockDocument({
+        id: "doc_existing",
+        createdAt: new Date("2026-01-01"),
+        isAutoLockEnabled: true,
+      });
+      mockStorage.get.mockResolvedValue(JSON.stringify([existing]));
+
+      const result = await repository.save({
+        id: "doc_existing",
+        typeId: "RG",
+        typeName: "RG novo",
+        fields: { fullName: "Ana Mudou" },
+        photos: { front: "newphotouri" },
+      });
+
+      expect(result.id).toBe("doc_existing");
+      expect(result.typeId).toBe("RG");
+      expect(result.fields.fullName).toBe("Ana Mudou");
+      // createdAt is preserved, not replaced
+      expect(result.createdAt.toISOString()).toBe(
+        new Date("2026-01-01").toISOString(),
+      );
+      // isAutoLockEnabled is preserved from the existing record
+      expect(result.isAutoLockEnabled).toBe(true);
+
+      // Storage was called with a single-entry array (no duplicate)
+      const persisted = JSON.parse(
+        (mockStorage.set as jest.Mock).mock.calls[0][1],
+      );
+      expect(persisted.length).toBe(1);
+      expect(persisted[0].id).toBe("doc_existing");
+    });
+
+    it("creates a new record when the id does not match any existing document", async () => {
+      const existing = createMockDocument({ id: "doc_a" });
+      mockStorage.get.mockResolvedValue(JSON.stringify([existing]));
+
+      const result = await repository.save({
+        id: "doc_missing",
+        typeId: "CNH",
+        typeName: "CNH",
+        fields: {},
+        photos: { front: "uri" },
+      });
+
+      // Fell through to the create path, so it got a fresh doc_* id
+      expect(result.id).toMatch(/^doc_\d+$/);
+      expect(result.id).not.toBe("doc_missing");
+
+      const persisted = JSON.parse(
+        (mockStorage.set as jest.Mock).mock.calls[0][1],
+      );
+      expect(persisted.length).toBe(2);
+    });
+
+    it("creates a new record when no id is supplied", async () => {
+      const existing = createMockDocument({ id: "doc_a" });
+      mockStorage.get.mockResolvedValue(JSON.stringify([existing]));
+
+      const result = await repository.save(mockDocumentInput);
+
+      expect(result.id).not.toBe("doc_a");
+      const persisted = JSON.parse(
+        (mockStorage.set as jest.Mock).mock.calls[0][1],
+      );
+      expect(persisted.length).toBe(2);
+    });
+  });
 });

--- a/src/data/repositories/document.repository.impl.ts
+++ b/src/data/repositories/document.repository.impl.ts
@@ -50,24 +50,42 @@ export class DocumentRepositoryImpl implements DocumentRepository {
         }
       }
 
-      const id = `doc_${Date.now()}`;
+      const documents = await this.findAll();
+      const existingIndex = input.id
+        ? documents.findIndex((doc) => doc.id === input.id)
+        : -1;
+      const now = new Date();
 
-      const document: Document = {
-        id,
+      if (existingIndex !== -1) {
+        const existing = documents[existingIndex];
+        const updated: Document = {
+          id: existing.id,
+          typeId: input.typeId,
+          typeName: input.typeName,
+          fields: { ...input.fields },
+          photos: encryptedPhotos,
+          isAutoLockEnabled: existing.isAutoLockEnabled,
+          createdAt: existing.createdAt,
+          updatedAt: now,
+        };
+        documents[existingIndex] = updated;
+        await this.storage.set(this.DOCUMENTS_KEY, JSON.stringify(documents));
+        return updated;
+      }
+
+      const created: Document = {
+        id: `doc_${Date.now()}`,
         typeId: input.typeId,
         typeName: input.typeName,
         fields: { ...input.fields },
         photos: encryptedPhotos,
         isAutoLockEnabled: false,
-        createdAt: new Date(),
-        updatedAt: new Date(),
+        createdAt: now,
+        updatedAt: now,
       };
-
-      const documents = await this.findAll();
-      documents.push(document);
+      documents.push(created);
       await this.storage.set(this.DOCUMENTS_KEY, JSON.stringify(documents));
-
-      return document;
+      return created;
     } catch (error) {
       console.error("Error saving document:", error);
       throw new Error("Failed to save document");

--- a/src/domain/entities/document.entity.ts
+++ b/src/domain/entities/document.entity.ts
@@ -13,6 +13,9 @@ export interface Document {
 }
 
 export interface DocumentInput {
+  // When present, `save` updates the existing document in-place and
+  // preserves `createdAt`. Absent means a new document is created.
+  id?: string;
   typeId: string;
   typeName: string;
   fields: Record<string, string>;

--- a/src/presentation/screens/add-document-screen.tsx
+++ b/src/presentation/screens/add-document-screen.tsx
@@ -159,6 +159,7 @@ export function AddDocumentScreen() {
 
       const result = await useCase.execute(
         {
+          id: isEditMode ? documentId : undefined,
           typeId: selectedTypeId,
           typeName: typeDefinition.label,
           fields,


### PR DESCRIPTION
## Summary

Bug reportado: editar um documento existente (incluindo trocar a foto) e clicar em Salvar criava um **novo registro** em vez de atualizar o original.

## Causa raiz

Duas peças faltando no caminho de edit:

1. **\`DocumentInput\` não tinha \`id\`** — a tela de \`add-document\` até sabia que estava em edit mode (\`isEditMode\` + \`documentId\` dos params), mas não tinha como informar o repositório de qual documento era pra atualizar.

2. **\`DocumentRepositoryImpl.save\` sempre criava novo**:
   \`\`\`ts
   const id = \`doc_\${Date.now()}\`;
   documents.push(document);  // ← sempre append
   \`\`\`
   Nenhum caminho de upsert. Só havia \`toggleAutoLock\` fazendo update in-place pra aquele campo específico.

## Fix

- \`DocumentInput\` ganha \`id?: string\` opcional
- \`DocumentRepositoryImpl.save\` vira upsert:
  - Se \`input.id\` bate com um documento existente → substitui in-place, **preservando \`createdAt\` e \`isAutoLockEnabled\`**
  - Caso contrário (sem id ou id órfão) → cai no caminho atual de create com id novo
- \`add-document-screen\` passa \`id: documentId\` quando em edit mode

## Test plan

- [x] \`npm test\` — 840 passando (3 novos cobrindo id+match, id+no-match, no-id)
- [x] \`npx tsc --noEmit\` sem novos erros
- [ ] QA: criar documento → abrir pra editar → alterar um campo → salvar → voltar pra home → existe só 1 registro, atualizado
- [ ] QA: criar documento → editar e trocar a foto → salvar → foto nova aparece no details, contagem na home não muda
- [ ] QA: criar documento → ativar auto-lock no details → voltar em add-document pra editar outro campo → salvar → auto-lock continua ligado (preservação)