### PR TITLE
perf(pin): defer re-hash + dev timing so we can actually measure unlock

### DIFF
--- a/src/domain/use-cases/verify-pin-with-lockout.use-case.test.ts
+++ b/src/domain/use-cases/verify-pin-with-lockout.use-case.test.ts
@@ -60,7 +60,7 @@ describe("VerifyPinWithLockoutUseCase", () => {
   const NOW = 1_700_000_000_000;
   const now = () => NOW;
 
-  it("returns success and resets attempts when PIN is correct (v2)", async () => {
+  it("returns success and resets attempts when there were previous bad tries", async () => {
     const pinRepo = mockPinRepository(V2_PIN);
     pinRepo.verify.mockResolvedValue(true);
     const attemptsRepo = mockAttemptsRepository({
@@ -77,10 +77,30 @@ describe("VerifyPinWithLockoutUseCase", () => {
     expect(attemptsRepo.reset).toHaveBeenCalled();
   });
 
+  it("skips the reset round-trip on a clean success (count already 0)", async () => {
+    const pinRepo = mockPinRepository(V2_PIN);
+    pinRepo.verify.mockResolvedValue(true);
+    const attemptsRepo = mockAttemptsRepository({
+      count: 0,
+      lastAttemptAt: 0,
+      lockedUntil: null,
+    });
+
+    const useCase = new VerifyPinWithLockoutUseCase(pinRepo, attemptsRepo, now);
+    const result = await useCase.execute("123456");
+
+    expect(result.success).toBe(true);
+    expect(attemptsRepo.reset).not.toHaveBeenCalled();
+  });
+
   it("migrates legacy PIN to v2 on successful verification", async () => {
     const pinRepo = mockPinRepository(LEGACY_PIN);
     pinRepo.verifyLegacy.mockResolvedValue(true);
-    const attemptsRepo = mockAttemptsRepository();
+    const attemptsRepo = mockAttemptsRepository({
+      count: 2,
+      lastAttemptAt: 0,
+      lockedUntil: null,
+    });
 
     const useCase = new VerifyPinWithLockoutUseCase(pinRepo, attemptsRepo, now);
     const result = await useCase.execute("123456");
@@ -191,7 +211,8 @@ describe("VerifyPinWithLockoutUseCase", () => {
     expect(pinRepo.save).not.toHaveBeenCalled();
   });
 
-  it("fires a background re-hash when stored iterations differ from current default", async () => {
+  it("defers the background re-hash so it doesn't compete with the post-unlock render", async () => {
+    jest.useFakeTimers();
     const pinRepo = mockPinRepository(V2_PIN_OLD);
     pinRepo.verify.mockResolvedValue(true);
     const attemptsRepo = mockAttemptsRepository();
@@ -199,8 +220,13 @@ describe("VerifyPinWithLockoutUseCase", () => {
     const useCase = new VerifyPinWithLockoutUseCase(pinRepo, attemptsRepo, now);
     const result = await useCase.execute("123456");
 
+    // The success return comes back immediately; the save is queued but
+    // hasn't fired yet, so the caller is free to navigate.
     expect(result.success).toBe(true);
-    expect(result.migrated).toBe(false);
+    expect(pinRepo.save).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(2000);
     expect(pinRepo.save).toHaveBeenCalledWith({ pin: "123456" });
+    jest.useRealTimers();
   });
 });

--- a/src/domain/use-cases/verify-pin-with-lockout.use-case.ts
+++ b/src/domain/use-cases/verify-pin-with-lockout.use-case.ts
@@ -14,6 +14,12 @@ export interface VerifyPinWithLockoutResult {
 }
 
 const PIN_LENGTH = 6;
+// How long to wait before running the opportunistic re-hash. The save
+// runs PBKDF2 again (~200-800ms on Hermes) on the same JS thread as the
+// UI, so firing it immediately after a successful verify competes with
+// navigation and the wallet-home first render. A short delay lets the
+// unlock flow settle before CPU gets hogged in the background.
+const REHASH_DEFER_MS = 2000;
 
 export class VerifyPinWithLockoutUseCase {
   constructor(
@@ -75,11 +81,24 @@ export class VerifyPinWithLockoutUseCase {
           migrated = true;
         } else if (stored.iterations !== PBKDF2_ITERATIONS) {
           // Opportunistically re-hash with the current iteration count so
-          // future unlocks are faster. Fire-and-forget: don't block unlock
-          // UX on this. If the save fails, the next login just retries.
-          void this.pinRepository.save({ pin }).catch(() => undefined);
+          // future unlocks are faster. Defer by a couple of seconds so
+          // the PBKDF2 work doesn't fight the wallet-home first render
+          // for the JS thread. Log failures in dev so we notice if the
+          // re-hash ever silently stops updating and leaves users stuck
+          // on the slower iteration count forever.
+          setTimeout(() => {
+            this.pinRepository.save({ pin }).catch((err) => {
+              if (__DEV__) {
+                console.warn("[PinVerify] opportunistic re-hash failed", err);
+              }
+            });
+          }, REHASH_DEFER_MS);
         }
-        await this.attemptsRepository.reset();
+        // Avoid a redundant SecureStore round-trip when the counter is
+        // already at zero (the common case — most unlocks are clean).
+        if (currentAttempts.count !== 0 || currentAttempts.lockedUntil !== null) {
+          await this.attemptsRepository.reset();
+        }
         return {
           success: true,
           lockedUntil: null,

--- a/src/domain/use-cases/verify-pin-with-lockout.use-case.ts
+++ b/src/domain/use-cases/verify-pin-with-lockout.use-case.ts
@@ -96,7 +96,10 @@ export class VerifyPinWithLockoutUseCase {
         }
         // Avoid a redundant SecureStore round-trip when the counter is
         // already at zero (the common case — most unlocks are clean).
-        if (currentAttempts.count !== 0 || currentAttempts.lockedUntil !== null) {
+        if (
+          currentAttempts.count !== 0 ||
+          currentAttempts.lockedUntil !== null
+        ) {
           await this.attemptsRepository.reset();
         }
         return {

--- a/src/presentation/components/document-photo-carousel.tsx
+++ b/src/presentation/components/document-photo-carousel.tsx
@@ -45,9 +45,7 @@ export function DocumentPhotoCarousel({
       >
         <Pressable
           style={{ width: photoWidth, marginRight: 16 }}
-          onPress={
-            onPhotoPress ? () => onPhotoPress(frontPhotoUri) : undefined
-          }
+          onPress={onPhotoPress ? () => onPhotoPress(frontPhotoUri) : undefined}
           accessibilityRole={onPhotoPress ? "button" : undefined}
         >
           <Image
@@ -59,9 +57,7 @@ export function DocumentPhotoCarousel({
         </Pressable>
         <Pressable
           style={{ width: photoWidth }}
-          onPress={
-            onPhotoPress ? () => onPhotoPress(backPhotoUri) : undefined
-          }
+          onPress={onPhotoPress ? () => onPhotoPress(backPhotoUri) : undefined}
           accessibilityRole={onPhotoPress ? "button" : undefined}
         >
           <Image

--- a/src/presentation/screens/unlock-wallet-screen.tsx
+++ b/src/presentation/screens/unlock-wallet-screen.tsx
@@ -87,12 +87,20 @@ export function UnlockWalletScreen() {
   const verifyPin = useCallback(
     async (value: string) => {
       setIsVerifyingPin(true);
+      // Dev-only instrumentation so slow unlocks on real devices can be
+      // inspected from Metro logs without attaching a profiler.
+      const startedAt = __DEV__ ? Date.now() : 0;
       try {
         const useCase = new VerifyPinWithLockoutUseCase(
           pinRepository,
           attemptsRepository,
         );
         const result = await useCase.execute(value);
+        if (__DEV__) {
+          console.log(
+            `[PinUnlock] verify took ${Date.now() - startedAt}ms success=${result.success}`,
+          );
+        }
         if (result.success) {
           setError(false);
           router.replace("/(tabs)");


### PR DESCRIPTION
## Summary

Usuário reportou login lento mesmo depois das otimizações do PR #170. Investiguei o hot path inteiro e achei três pontos concretos + falta de instrumentação:

### 1. Re-hash oportunista competindo com a navegação

\`verify-pin-with-lockout\` dispara \`void pinRepository.save({ pin })\` logo após um verify bem-sucedido quando o PIN armazenado tem iterations diferentes do default atual (50k). É fire-and-forget mas **roda na mesma thread JS**, então o PBKDF2 novo (~200-800ms em Hermes) disputa com o \`router.replace(\"/(tabs)\")\` e o primeiro render da wallet-home.

**Fix:** \`setTimeout(save, 2000)\`. O unlock retorna imediatamente, usuário navega, 2s depois o re-hash roda em background sem atrapalhar o render. Próximo unlock já tem as iterations novas.

### 2. Falha silenciosa do re-hash

\`.catch(() => undefined)\` engolia qualquer erro. Se o save falhasse por algum motivo, o iterations antigo ficava pra sempre e cada unlock continuava lento.

**Fix:** \`console.warn\` em dev quando o re-hash falha. Sem mudança de comportamento em prod (produção não passa pelo \`__DEV__\`).

### 3. Reset de attempts no caso comum

\`attemptsRepository.reset()\` disparava SecureStore.deleteItemAsync em todo unlock, incluindo quando o contador já era 0. Round-trip desperdiçado no caso mais comum (usuário acerta de primeira).

**Fix:** skip reset quando \`count === 0 && lockedUntil === null\`.

### 4. Sem instrumentação — agora tem

Adicionado \`console.log(\`[PinUnlock] verify took Nms\`)\` na unlock-wallet-screen, só em \`__DEV__\`. Próxima vez que alguém reportar lentidão, Metro log vai dizer exatamente quanto tempo o verify levou. Se for 300ms e o usuário sente lento, o gargalo está depois do verify (render, decrypt das fotos etc). Se for 2000ms, é PBKDF2 mesmo.

## Test plan

- [x] \`npm test\` — 841 passando (2 novos: deferred re-hash via fake timers, skip-reset-on-clean-success)
- [x] \`npx tsc --noEmit\` sem novos erros
- [ ] QA: login com PIN correto → Metro log mostra \`[PinUnlock] verify took Xms\`
- [ ] QA: se o usuário tinha PIN antigo (210k) — primeiro login depois do merge ainda é mais lento, mas nos subsequentes já deve ser rápido
- [ ] QA: se o re-hash falhar por algum motivo, \`[PinVerify] opportunistic re-hash failed\` aparece no log